### PR TITLE
Increase thread priority for the rendering thread

### DIFF
--- a/include/mbgl/util/platform.hpp
+++ b/include/mbgl/util/platform.hpp
@@ -22,6 +22,12 @@ void setCurrentThreadName(const std::string &name);
 /// Makes the current thread low priority.
 void makeThreadLowPriority();
 
+/// Makes the current thread high priority.
+void makeThreadHighPriority();
+
+/// Get the current thread priority.
+double getCurrentThreadPriority();
+
 /// Sets priority of a current thread. Platform implementation
 /// must validate provided value.
 void setCurrentThreadPriority(double priority);

--- a/platform/android/MapLibreAndroid/src/cpp/geojson/feature.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/geojson/feature.cpp
@@ -2,6 +2,7 @@
 #include "geometry.hpp"
 #include "../gson/json_object.hpp"
 
+#include <mbgl/util/instrumentation.hpp>
 #include <mbgl/util/string.hpp>
 
 namespace mbgl {
@@ -11,6 +12,8 @@ namespace geojson {
 using namespace gson;
 
 mbgl::GeoJSONFeature Feature::convert(jni::JNIEnv& env, const jni::Object<Feature>& jFeature) {
+    MLN_TRACE_FUNC();
+
     static auto& javaClass = jni::Class<Feature>::Singleton(env);
     static auto id = javaClass.GetMethod<jni::String()>(env, "id");
     static auto geometry = javaClass.GetMethod<jni::Object<Geometry>()>(env, "geometry");

--- a/platform/android/MapLibreAndroid/src/cpp/geojson/geometry_collection.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/geojson/geometry_collection.cpp
@@ -1,6 +1,8 @@
 #include "geometry_collection.hpp"
 #include "../java/util.hpp"
 
+#include <mbgl/util/instrumentation.hpp>
+
 namespace mbgl {
 namespace android {
 namespace geojson {
@@ -23,6 +25,8 @@ jni::Local<jni::Object<GeometryCollection>> GeometryCollection::New(
 
 mapbox::geometry::geometry_collection<double> GeometryCollection::convert(
     jni::JNIEnv& env, const jni::Object<GeometryCollection>& jCollection) {
+    MLN_TRACE_FUNC();
+
     // Get geometries
     static auto& javaClass = jni::Class<GeometryCollection>::Singleton(env);
     static auto getGeometries = javaClass.GetMethod<jni::Object<java::util::List>()>(env, "geometries");

--- a/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
@@ -4,6 +4,7 @@
 #include <mbgl/renderer/renderer.hpp>
 #include <mbgl/util/instrumentation.hpp>
 #include <mbgl/util/logging.hpp>
+#include <mbgl/util/platform.hpp>
 #include <mbgl/util/run_loop.hpp>
 
 #include <string>
@@ -232,6 +233,9 @@ void MapRenderer::render(JNIEnv&) {
 void MapRenderer::onSurfaceCreated(JNIEnv& env, const jni::Object<AndroidSurface>& surface) {
     // Lock as the initialization can come from the main thread or the GL thread first
     std::lock_guard<std::mutex> lock(initialisationMutex);
+
+    platform::makeThreadHighPriority();
+    Log::Debug(Event::Android, "Setting render thread priority to " + std::to_string(platform::getCurrentThreadPriority()));
 
     // The android system will have already destroyed the underlying
     // GL resources if this is not the first initialization and an

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -22,6 +22,7 @@
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/logging.hpp>
+#include <mbgl/util/instrumentation.hpp>
 #include <mbgl/util/platform.hpp>
 #include <mbgl/util/projection.hpp>
 #include <mbgl/style/style.hpp>
@@ -478,6 +479,8 @@ jni::Local<jni::Object<CameraPosition>> NativeMapView::getCameraForGeometry(
     double right,
     double bearing,
     double tilt) {
+    MLN_TRACE_FUNC();
+
     auto geometry = geojson::Geometry::convert(env, jGeometry);
     mbgl::EdgeInsets padding = {top, left, bottom, right};
     return CameraPosition::New(env, map->cameraForGeometry(geometry, padding, bearing, tilt), pixelRatio);

--- a/platform/android/src/thread.cpp
+++ b/platform/android/src/thread.cpp
@@ -40,6 +40,18 @@ void makeThreadLowPriority() {
     setpriority(PRIO_PROCESS, 0, 19);
 }
 
+void makeThreadHighPriority() {
+    // ANDROID_PRIORITY_HIGHEST = -20
+    //
+    // Supposedly would set the priority for the whole process, but
+    // on Linux/Android it only sets for the current thread.
+    setpriority(PRIO_PROCESS, 0, -20);
+}
+
+double getCurrentThreadPriority() {
+    return getpriority(PRIO_PROCESS, 0);
+}
+
 void setCurrentThreadPriority(double priority) {
     if (priority < -20 || priority > 19) {
         Log::Warning(Event::General, "Couldn't set thread priority");

--- a/platform/darwin/src/nsthread.mm
+++ b/platform/darwin/src/nsthread.mm
@@ -25,6 +25,26 @@ void makeThreadLowPriority() {
     [NSThread currentThread].qualityOfService = NSQualityOfServiceUtility;
 }
 
+void makeThreadHighPriority() {
+    [NSThread currentThread].qualityOfService = NSQualityOfServiceUserInteractive;
+}
+
+double getCurrentThreadPriority() {
+    NSQualityOfService qualityOfService = [NSThread currentThread].qualityOfService;
+    switch (qualityOfService) {
+        case NSQualityOfServiceBackground:
+            return 0.0;
+        case NSQualityOfServiceUtility:
+            return 0.25;
+        case NSQualityOfServiceUserInitiated:
+            return 0.5;
+        case NSQualityOfServiceUserInteractive:
+            return 1.0;
+        default:
+            return 0.5;
+    }
+}
+
 void setCurrentThreadPriority(double priority) {
     if (priority > 1.0 || priority < 0.0) {
         Log::Warning(Event::General, "Invalid thread priority was provided");

--- a/platform/default/src/mbgl/util/thread.cpp
+++ b/platform/default/src/mbgl/util/thread.cpp
@@ -41,6 +41,14 @@ void makeThreadLowPriority() {
 #endif
 }
 
+void makeThreadHighPriority() {
+    setCurrentThreadPriority(-20);
+}
+
+double getCurrentThreadPriority() {
+    return getpriority(PRIO_PROCESS, 0);
+}
+
 void setCurrentThreadPriority(double priority) {
     if (setpriority(PRIO_PROCESS, 0, int(priority)) < 0) {
         Log::Warning(Event::General, "Couldn't set thread priority");

--- a/platform/qt/src/mbgl/thread.cpp
+++ b/platform/qt/src/mbgl/thread.cpp
@@ -14,6 +14,10 @@ void setCurrentThreadName(const std::string&) {}
 
 void makeThreadLowPriority() {}
 
+void makeThreadHighPriority() {}
+
+double getCurrentThreadPriority() { return 0;}
+
 void setCurrentThreadPriority(double) {}
 
 void attachThread() {}

--- a/platform/windows/include/thread.h
+++ b/platform/windows/include/thread.h
@@ -60,6 +60,8 @@ namespace platform {
 std::string getCurrentThreadName();
 void setCurrentThreadName(const std::string& name);
 void makeThreadLowPriority();
+void makeThreadHighPriority();
+double getCurrentThreadPriority();
 void setCurrentThreadPriority(double priority);
 } // namespace platform
 } // namespace mbgl

--- a/platform/windows/src/thread.cpp
+++ b/platform/windows/src/thread.cpp
@@ -74,6 +74,16 @@ void makeThreadLowPriority() {
     }
 }
 
+void makeThreadHighPriority() {
+    if (!SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL)) {
+        Log::Warning(Event::General, "Couldn't set thread scheduling policy");
+    }
+}
+
+double getCurrentThreadPriority() {
+    return GetThreadPriority(GetCurrentThread());
+}
+
 void setCurrentThreadPriority(double priority) {
     if (!SetThreadPriority(GetCurrentThread(), int(priority))) {
         Log::Warning(Event::General, "Couldn't set thread priority");


### PR DESCRIPTION
In CPU bound situations, Android apps with many active threads can become unresponsive (hitching). Within MapLibre the render thread is the thread where hitches are noticeable. This PR sets a high priority for the render thread to reduce hitches when the app is CPU limited.