### PR TITLE
Make the number of displayed tiles accessible to Android client appli…

### DIFF
--- a/include/mbgl/renderer/renderer.hpp
+++ b/include/mbgl/renderer/renderer.hpp
@@ -113,6 +113,8 @@ public:
     void reduceMemoryUse();
     void clearData();
 
+    int getLastRenderedTileCount() const noexcept { return lastRenderedTileCount; }
+
 #if MLN_RENDER_BACKEND_OPENGL
     void enableAndroidEmulatorGoldfishMitigation(bool enable);
 #endif
@@ -120,6 +122,8 @@ public:
 private:
     class Impl;
     std::unique_ptr<Impl> impl;
+
+    int lastRenderedTileCount = 0;
 };
 
 } // namespace mbgl

--- a/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
@@ -337,5 +337,12 @@ MapRenderer& MapRenderer::getNativePeer(JNIEnv& env, const jni::Object<MapRender
     return *mapRenderer;
 }
 
+int MapRenderer::getLastRenderedTileCount() const noexcept {
+    if (!renderer) {
+        return 0;
+    }
+    return renderer->getLastRenderedTileCount();
+}
+
 } // namespace android
 } // namespace mbgl

--- a/platform/android/MapLibreAndroid/src/cpp/map_renderer.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/map_renderer.hpp
@@ -90,6 +90,8 @@ public:
     AndroidRendererBackend& getRendererBackend() const { return *backend; }
     const TaggedScheduler& getThreadPool() const { return threadPool; }
 
+    int getLastRenderedTileCount() const noexcept;
+
 protected:
     // Called from the GL Thread //
 

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -1252,6 +1252,10 @@ jni::jdouble NativeMapView::getTileLodZoomShift(JNIEnv&) {
     return jni::jdouble(map->getTileLodZoomShift());
 }
 
+jni::jint NativeMapView::getLastRenderedTileCount(JNIEnv&) {
+    return jni::jint(mapRenderer.getLastRenderedTileCount());
+}
+
 mbgl::Map& NativeMapView::getMap() {
     return *map;
 }
@@ -1379,6 +1383,7 @@ void NativeMapView::registerNative(jni::JNIEnv& env) {
         METHOD(&NativeMapView::getTileLodPitchThreshold, "nativeGetTileLodPitchThreshold"),
         METHOD(&NativeMapView::setTileLodZoomShift, "nativeSetTileLodZoomShift"),
         METHOD(&NativeMapView::getTileLodZoomShift, "nativeGetTileLodZoomShift"),
+        METHOD(&NativeMapView::getLastRenderedTileCount, "nativeGetLastRenderedTileCount"),
         METHOD(&NativeMapView::triggerRepaint, "nativeTriggerRepaint"));
 }
 

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
@@ -311,6 +311,8 @@ public:
 
     jni::jdouble getTileLodZoomShift(JNIEnv&);
 
+    jni::jint getLastRenderedTileCount(JNIEnv&);
+
     mbgl::Map& getMap();
 
     void triggerRepaint(JNIEnv&);

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapLibreMap.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapLibreMap.java
@@ -466,6 +466,15 @@ public final class MapLibreMap {
     return transform.getMinZoom();
   }
 
+  /**
+   * Get the number of tiles rendered in the last frame.
+   *
+   * @return number of tiles rendered in the last frame.
+   */
+  public int getLastRenderedTileCount() {
+    return nativeMapView.getLastRenderedTileCount();
+  }
+
   //
   // MaxZoom
   //

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMap.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMap.java
@@ -261,6 +261,8 @@ interface NativeMap {
 
   void setSwapBehaviorFlush(boolean flush);
 
+  int getLastRenderedTileCount();
+
   //
   // Deprecated Annotations API
   //

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
@@ -887,6 +887,14 @@ final class NativeMapView implements NativeMap {
     }
     return nativeGetTileLodZoomShift();
   }
+
+  @Override
+  public int getLastRenderedTileCount() {
+    if (checkState("getLastRenderedTileCount")) {
+      return 0;
+    }
+    return nativeGetLastRenderedTileCount();
+  }
   // Runtime style Api
 
   @Override
@@ -1681,6 +1689,9 @@ final class NativeMapView implements NativeMap {
 
   @Keep
   private native double nativeGetTileLodZoomShift();
+
+  @Keep
+  private native int nativeGetLastRenderedTileCount();
 
   @Override
   public long getNativePtr() {

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -131,6 +131,9 @@ public:
     // Checks whether the given zoom is inside this layer zoom range.
     bool supportsZoom(float zoom) const;
 
+    // Return the number of tiles to display for this layer
+    int renderTileCount() const noexcept { return renderTiles ? static_cast<int>(renderTiles->size()) : 0; }
+
     virtual void upload(gfx::UploadPass&) {}
     virtual void render(PaintParameters&) {}
 

--- a/src/mbgl/renderer/renderer.cpp
+++ b/src/mbgl/renderer/renderer.cpp
@@ -35,6 +35,11 @@ void Renderer::render(const std::shared_ptr<UpdateParameters>& updateParameters)
     if (auto renderTree = impl->orchestrator.createRenderTree(updateParameters)) {
         renderTree->prepare();
         impl->render(*renderTree, updateParameters);
+
+        // Number of rendered tiles (All layers have the same number)
+        if (renderTree->getLayerRenderItemMap().size() > 0) {
+            lastRenderedTileCount = renderTree->getLayerRenderItemMap().begin()->layer.get().renderTileCount();
+        }
     }
 }
 


### PR DESCRIPTION
…cations

This PR expose the number of tiles last rendered to the client application. This information is useful to the client application when testing rendering performance. i.e. performance usually scales with the number of displayed tiles