### PR TITLE
Add location NaN error checking

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationAnimatorCustomPuck.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationAnimatorCustomPuck.java
@@ -34,6 +34,9 @@ final class LocationAnimatorCustomPuck {
       this.lon = lon;
       this.bearing = bearing;
       this.time = time;
+      if (Double.isNaN(lat) || Double.isNaN(lon) || Double.isNaN(bearing)) {
+        throw new RuntimeException("Unexpected puck location: lat=" + lat + ", lon=" + lon + ", bearing=" + bearing);
+      }
     }
 
     public StampedLatLon(StampedLatLon other) {

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationComponent.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationComponent.java
@@ -260,6 +260,14 @@ public final class LocationComponent {
     customPuckAnimationOptions.animationIntervalMS = activationOptions.customPuckAnimationIntervalMS();
     customPuckAnimationOptions.lagMS = activationOptions.customPuckLagMS();
     customPuckAnimationOptions.iconScale = activationOptions.customPuckIconScale();
+    if (customPuckAnimationOptions.customPuckAnimationEnabled) {
+      if (customPuckAnimationOptions.lagMS <= 0) {
+        throw new RuntimeException("Custom puck lag must be greater than 0");
+      }
+      if (customPuckAnimationOptions.iconScale <= 0) {
+        throw new RuntimeException("Custom puck icon scale must be greater than 0");
+      }
+    }
 
     // Initialize the LocationComponent with Context, the map's `Style`, and either custom LocationComponentOptions
     // or backup options created from default/custom attributes
@@ -1282,6 +1290,9 @@ public final class LocationComponent {
   private void updateLocation(@Nullable final Location location, @Nullable List<Location> intermediatePoints,
                               boolean fromLastLocation, boolean lookAheadUpdate) {
     if (location == null) {
+      return;
+    } else if (Utils.locationHasNaN(location)) {
+      Logger.e(TAG, "Skipping invalid location: " + location.toString());
       return;
     } else if (!isLayerReady) {
       lastLocation = location;

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/Utils.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/Utils.java
@@ -44,6 +44,18 @@ public final class Utils {
   }
 
   /**
+   * Check if NaN is present in a Location
+   *
+   * @param location location
+   * @return true if NaN is present, false otherwise
+   */
+  public static boolean locationHasNaN(Location location) {
+    return Double.isNaN(location.getLatitude())
+           || Double.isNaN(location.getLongitude())
+           || Double.isNaN(location.getBearing());
+  }
+
+  /**
    * Normalizes an angle to be in the [0, 360] range.
    *
    * @param angle the provided angle


### PR DESCRIPTION
Add error checking related to puck rendering errors.
If the location fed to MapLibre is wrong (contains NaN), an error is logged and the location is ignored.
If a NaN is detect downstream an fatal exception is thrown