### PR TITLE
Multi stops lod shift

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -175,14 +175,16 @@ public:
     /// A negative values typically improves performance but reduces quality.
     /// For instance, a value of -1 reduces the zoom level by 1 and this
     /// reduces the number of tiles by a factor of 4 for the same camera view.
+    /// shift is an array of pairs. The pair first element is the zoom level and
+    /// the second element is the shift value.
     void setTileLodMinRadius(double radius);
     double getTileLodMinRadius() const;
     void setTileLodScale(double scale);
     double getTileLodScale() const;
     void setTileLodPitchThreshold(double threshold);
     double getTileLodPitchThreshold() const;
-    void setTileLodZoomShift(double shift);
-    double getTileLodZoomShift() const;
+    void setTileLodZoomShift(const std::vector<double>& shift);
+    double getTileLodZoomShift(double zoom) const;
 
 protected:
     class Impl;

--- a/include/mbgl/map/map_lod_shift.hpp
+++ b/include/mbgl/map/map_lod_shift.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cassert>
+#include <vector>
+
+namespace mbgl {
+
+class MapLodShift {
+public:
+    MapLodShift() = default;
+
+    MapLodShift(const std::vector<double>& data) {
+        assert(data.size() % 2 == 0);
+        size_t size = data.size() / 2;
+        zoom.resize(size);
+        shift.resize(size);
+        for (size_t i = 0; i < size; i++) {
+            zoom[i] = data[i * 2];
+            shift[i] = data[i * 2 + 1];
+        }
+    }
+
+    double get(double z) const {
+        if (zoom.empty()) {
+            return 0;
+        }
+        if (z <= zoom.front()) {
+            return shift.front();
+        }
+        if (z >= zoom.back()) {
+            return shift.back();
+        }
+        for (size_t i = 1; i < zoom.size(); i++) {
+            if (z < zoom[i]) {
+                double t = (z - zoom[i - 1]) / (zoom[i] - zoom[i - 1]);
+                return shift[i - 1] + t * (shift[i] - shift[i - 1]);
+            }
+        }
+        return 0;
+    }
+
+private:
+    std::vector<double> zoom;
+    std::vector<double> shift;
+};
+
+} // namespace mbgl

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -1306,12 +1306,17 @@ jni::jdouble NativeMapView::getTileLodPitchThreshold(JNIEnv&) {
     return jni::jdouble(map->getTileLodPitchThreshold());
 }
 
-void NativeMapView::setTileLodZoomShift(JNIEnv&, jni::jdouble shift) {
-    map->setTileLodZoomShift(shift);
+void NativeMapView::setTileLodZoomShift(JNIEnv& env, const jni::Array<jni::jdouble>& shift) {
+    assert(shift.Length(env) % 2 == 0);
+    std::vector<double> shiftVec(shift.Length(env));
+    for (std::size_t i = 0; i < shift.Length(env); i++) {
+        shiftVec[i] = shift.Get(env, i);
+    }
+    map->setTileLodZoomShift(shiftVec);
 }
 
-jni::jdouble NativeMapView::getTileLodZoomShift(JNIEnv&) {
-    return jni::jdouble(map->getTileLodZoomShift());
+jni::jdouble NativeMapView::getTileLodZoomShift(JNIEnv&, jni::jdouble zoom) {
+    return jni::jdouble(map->getTileLodZoomShift(zoom));
 }
 
 jni::jint NativeMapView::getLastRenderedTileCount(JNIEnv&) {

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
@@ -352,9 +352,9 @@ public:
 
     jni::jdouble getTileLodPitchThreshold(JNIEnv&);
 
-    void setTileLodZoomShift(JNIEnv&, jni::jdouble);
+    void setTileLodZoomShift(JNIEnv&, const jni::Array<jni::jdouble>&);
 
-    jni::jdouble getTileLodZoomShift(JNIEnv&);
+    jni::jdouble getTileLodZoomShift(JNIEnv&, jni::jdouble);
 
     jni::jint getLastRenderedTileCount(JNIEnv&);
 

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapLibreMap.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapLibreMap.java
@@ -424,19 +424,22 @@ public final class MapLibreMap {
    * displayed tiles by a factor of 4 on average
    * It is recommended to first configure the pixelRatio before adjusting
    * TileLodZoomShift. {@link MapLibreMapOptions#pixelRatio(float)}
+   * shift is an array of pairs. The pair first element is the zoom level and
+   * the second element is the shift value.
    */
-  public void setTileLodZoomShift(double shift) {
+  public void setTileLodZoomShift(double[] shift) {
     nativeMapView.setTileLodZoomShift(shift);
   }
 
   /**
    * Camera based tile level of detail controls
    *
+   * @param zoom Zoom level for which the shift is returned
    * @return shift applied to the Zoom level during LOD calculation
-   * @see MapLibreMap#setTileLodZoomShift(double)
+   * @see MapLibreMap#setTileLodZoomShift(double[])
    */
-  public double getTileLodZoomShift() {
-    return nativeMapView.getTileLodZoomShift();
+  public double getTileLodZoomShift(double zoom) {
+    return nativeMapView.getTileLodZoomShift(zoom);
   }
 
   //

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMap.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMap.java
@@ -252,9 +252,9 @@ interface NativeMap {
 
   double getTileLodPitchThreshold();
 
-  void setTileLodZoomShift(double shift);
+  void setTileLodZoomShift(double[] shift);
 
-  double getTileLodZoomShift();
+  double getTileLodZoomShift(double zoom);
 
   void setGestureInProgress(boolean inProgress);
 

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
@@ -879,7 +879,7 @@ final class NativeMapView implements NativeMap {
   }
 
   @Override
-  public void setTileLodZoomShift(double shift) {
+  public void setTileLodZoomShift(double[] shift) {
     if (checkState("setTileLodZoomShift")) {
       return;
     }
@@ -887,11 +887,11 @@ final class NativeMapView implements NativeMap {
   }
 
   @Override
-  public double getTileLodZoomShift() {
+  public double getTileLodZoomShift(double zoom) {
     if (checkState("getTileLodZoomShift")) {
       return 0;
     }
-    return nativeGetTileLodZoomShift();
+    return nativeGetTileLodZoomShift(zoom);
   }
 
   @Override
@@ -1848,10 +1848,10 @@ final class NativeMapView implements NativeMap {
   private native double nativeGetTileLodPitchThreshold();
 
   @Keep
-  private native void nativeSetTileLodZoomShift(double shift);
+  private native void nativeSetTileLodZoomShift(double[] shift);
 
   @Keep
-  private native double nativeGetTileLodZoomShift();
+  private native double nativeGetTileLodZoomShift(double zoom);
 
   @Keep
   private native int nativeGetLastRenderedTileCount();

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -163,10 +163,10 @@ void cycleTileLodMode(mbgl::Map &map) {
 void tileLodZoomShift(mbgl::Map &map, bool positive) {
     constexpr auto tileLodZoomShiftStep = 0.25;
     auto shift = positive ? tileLodZoomShiftStep : -tileLodZoomShiftStep;
-    shift = map.getTileLodZoomShift() + shift;
+    shift = map.getTileLodZoomShift(0) + shift;
     shift = mbgl::util::clamp(shift, -2.5, 2.5);
     mbgl::Log::Info(mbgl::Event::OpenGL, "Zoom shift: " + std::to_string(shift));
-    map.setTileLodZoomShift(shift);
+    map.setTileLodZoomShift({0, shift});
     map.triggerRepaint();
 }
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -3,6 +3,7 @@
 #include <mbgl/map/camera.hpp>
 #include <mbgl/map/map.hpp>
 #include <mbgl/map/map_impl.hpp>
+#include <mbgl/map/map_lod_shift.hpp>
 #include <mbgl/map/transform.hpp>
 #include <mbgl/math/angles.hpp>
 #include <mbgl/math/log2.hpp>
@@ -551,12 +552,12 @@ double Map::getTileLodPitchThreshold() const {
     return impl->tileLodPitchThreshold;
 }
 
-void Map::setTileLodZoomShift(double shift) {
-    impl->tileLodZoomShift = shift;
+void Map::setTileLodZoomShift(const std::vector<double>& shift) {
+    impl->tileLodZoomShift = MapLodShift(shift);
 }
 
-double Map::getTileLodZoomShift() const {
-    return impl->tileLodZoomShift;
+double Map::getTileLodZoomShift(double zoom) const {
+    return impl->tileLodZoomShift.get(zoom);
 }
 
 } // namespace mbgl

--- a/src/mbgl/map/map_impl.hpp
+++ b/src/mbgl/map/map_impl.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/annotation/annotation_manager.hpp>
 #include <mbgl/map/map.hpp>
+#include <mbgl/map/map_lod_shift.hpp>
 #include <mbgl/map/map_observer.hpp>
 #include <mbgl/map/map_options.hpp>
 #include <mbgl/map/mode.hpp>
@@ -96,7 +97,7 @@ public:
     double tileLodMinRadius = 3;
     double tileLodScale = 1;
     double tileLodPitchThreshold = (60.0 / 180.0) * std::numbers::pi;
-    double tileLodZoomShift = 0;
+    MapLodShift tileLodZoomShift;
 };
 
 // Forward declaration of this method is required for the MapProjection class

--- a/src/mbgl/renderer/tile_parameters.hpp
+++ b/src/mbgl/renderer/tile_parameters.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mbgl/map/map_lod_shift.hpp>
 #include <mbgl/map/mode.hpp>
 #include <mbgl/actor/scheduler.hpp>
 
@@ -31,7 +32,7 @@ public:
     double tileLodMinRadius = 3;
     double tileLodScale = 1;
     double tileLodPitchThreshold = (60.0 / 180.0) * std::numbers::pi;
-    double tileLodZoomShift = 0;
+    MapLodShift tileLodZoomShift;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -90,8 +90,8 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
     handleWrapJump(static_cast<float>(parameters.transformState.getLatLng().longitude()));
 
     // Optionally shift the zoom level
-    double zoom = util::clamp<double>(
-        parameters.transformState.getZoom() + parameters.tileLodZoomShift, zoomRange.min, zoomRange.max);
+    double shift = parameters.tileLodZoomShift.get(parameters.transformState.getZoom());
+    double zoom = util::clamp<double>(parameters.transformState.getZoom() + shift, zoomRange.min, zoomRange.max);
 
     const auto type = sourceImpl.type;
     // Determine the overzooming/underzooming amounts and required tiles.

--- a/src/mbgl/renderer/update_parameters.hpp
+++ b/src/mbgl/renderer/update_parameters.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mbgl/map/map_lod_shift.hpp>
 #include <mbgl/map/mode.hpp>
 #include <mbgl/map/transform_state.hpp>
 #include <mbgl/style/light.hpp>
@@ -49,7 +50,7 @@ public:
     double tileLodMinRadius = 3;
     double tileLodScale = 1;
     double tileLodPitchThreshold = (60.0 / 180.0) * std::numbers::pi;
-    double tileLodZoomShift = 0;
+    MapLodShift tileLodZoomShift;
 };
 
 } // namespace mbgl


### PR DESCRIPTION
Allow finer control of LOD shift by passing an array of shifts at different zoom levels instead of a global shift

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alproton/maplibre-native/7)
<!-- Reviewable:end -->
