### PR TITLE
fixes for the gradient bug

### DIFF
--- a/include/mbgl/route/route.hpp
+++ b/include/mbgl/route/route.hpp
@@ -1,10 +1,14 @@
 
 #pragma once
 
+#include <mbgl/route/route_segment.hpp>
+
 #include <mbgl/util/geometry.hpp>
 #include <mbgl/util/color.hpp>
 #include <vector>
 #include <map>
+#include <set>
+
 namespace mbgl {
 namespace route {
 
@@ -56,12 +60,18 @@ private:
         Color color;
     };
 
+    struct SegmentComparator {
+        bool operator()(const RouteSegment& lhs, const RouteSegment& rhs) const {
+            return lhs.getNormalizedPositions()[0] < rhs.getNormalizedPositions()[0];
+        }
+    };
+
     std::vector<SegmentRange> compactSegments() const;
 
     RouteOptions routeOptions_;
     double progress_ = 0.0;
     std::vector<double> segDistances_;
-    std::vector<RouteSegment> segments_;
+    std::set<RouteSegment, SegmentComparator> segments_;
     mbgl::LineString<double> geometry_;
     std::map<double, mbgl::Color> segGradient_;
     double totalDistance_ = 0.0;

--- a/src/mbgl/route/route_segment.cpp
+++ b/src/mbgl/route/route_segment.cpp
@@ -55,6 +55,7 @@ RouteSegment::RouteSegment(const RouteSegmentOptions& routeSegOptions,
     // calculate the normalized points and the expressions
     double currDist = 0.0;
     for (const auto& pt : routeSegOptions.geometry) {
+        bool ptIntersectionFound = false;
         for (size_t i = 1; i < routeGeometry.size(); ++i) {
             const mbgl::Point<double>& pt1 = routeGeometry[i - 1];
             const mbgl::Point<double>& pt2 = pt;
@@ -63,13 +64,17 @@ RouteSegment::RouteSegment(const RouteSegmentOptions& routeSegOptions,
             if (isPointBetween(pt2, pt1, pt3)) {
                 double partialDist = mbgl::util::dist<double>(pt1, pt2);
                 currDist += partialDist;
+                ptIntersectionFound = true;
                 break;
             } else {
                 currDist += routeGeomDistances[i - 1];
             }
         }
-        double normalizedDist = currDist / routeTotalDistance;
-        normalizedPositions_.push_back(normalizedDist);
+
+        if (ptIntersectionFound) {
+            double normalizedDist = currDist / routeTotalDistance;
+            normalizedPositions_.push_back(normalizedDist);
+        }
 
         currDist = 0.0;
     }


### PR DESCRIPTION
Issues:
The infamous gradient bug were due to following situations:
1) some of the points in the route  segments did not lie on the route or even close to the entire route. I loop through each route segment point to store its normalized distance within route. Since this point was not found close to the entire route, all of the route point intervals  were searched and the "distance so far" variable went full to the full distance of the route and incorrectly calculated that the point's distance is 1. This caused problems when calculating the gradient.
2) last attempt did resolve for overlapping route segments but there was a missing = when checking if the routes intersected.

Fixing these two helped resolve the bug that was captured via snapshot capturing system implemented last release.