### PR TITLE
added support for oneline stats

### DIFF
--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -61,6 +61,11 @@
 #include "tile/tile_operation.hpp"
 #include "mbgl/route/route_manager.hpp"
 #include "mbgl/route/route.hpp"
+#include <rapidjson/document.h>
+#include <rapidjson/prettywriter.h>
+#include <rapidjson/error/en.h>
+#include <rapidjson/rapidjson.h>
+#include <rapidjson/stringbuffer.h>
 
 #include "android_renderer_backend.hpp"
 
@@ -1731,14 +1736,38 @@ jboolean NativeMapView::routesFinalize(JNIEnv& env) {
     return false;
 }
 
-jni::Local<jni::String> NativeMapView::getRenderingStats(JNIEnv& env) {
+jni::Local<jni::String> NativeMapView::getRenderingStats(JNIEnv& env, jni::jboolean oneline) {
     std::stringstream ss;
-    gfx::RenderingStats stats = mapRenderer.getRenderingStats();
-    ss << stats.toJSONString();
-    if (routeMgr) {
-        ss << routeMgr->getStats();
+    std::string renderingStats = mapRenderer.getRenderingStats().toJSONString();
+    std::string routeStats = routeMgr->getStats();
+    rapidjson::Document renderStatsDoc;
+    renderStatsDoc.Parse(renderingStats.c_str());
+    rapidjson::Document routeStatsDoc;
+    routeStatsDoc.Parse(routeStats.c_str());
+
+    rapidjson::Document combined;
+    combined.SetObject();
+
+    rapidjson::Document::AllocatorType& combinedAllocator = combined.GetAllocator();
+
+    rapidjson::Value copiedRenderingStats(renderStatsDoc, combinedAllocator);
+    rapidjson::Value copiedRouteStats(routeStatsDoc, combinedAllocator);
+
+    combined.AddMember("rendering_stats", copiedRenderingStats, combinedAllocator);
+    combined.AddMember("route_stats", copiedRouteStats, combinedAllocator);
+
+    rapidjson::StringBuffer buffer;
+    rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(buffer);
+    combined.Accept(writer);
+
+    std::string jsonString = buffer.GetString();
+
+    if (oneline) {
+        jsonString.erase(std::remove(jsonString.begin(), jsonString.end(), '\n'), jsonString.end());
+        jsonString.erase(std::remove(jsonString.begin(), jsonString.end(), '\t'), jsonString.end());
     }
-    return jni::Make<jni::String>(env, ss.str());
+
+    return jni::Make<jni::String>(env, jsonString);
 }
 
 void NativeMapView::onRegisterShaders(gfx::ShaderRegistry&) {};

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
@@ -275,7 +275,7 @@ public:
     jboolean routesFinalize(JNIEnv& env);
     //------------------------------------------------
 
-    jni::Local<jni::String> getRenderingStats(JNIEnv& env);
+    jni::Local<jni::String> getRenderingStats(JNIEnv& env, jni::jboolean oneline);
 
     jni::jdouble getTopOffsetPixelsForAnnotationSymbol(JNIEnv&, const jni::String&);
 

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapView.java
@@ -559,10 +559,12 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
    * Gets statistics of the underlying health of routes management and includes stats on various
    * constructs built in native code, such as memory and time take for such constructs.
    *
+   * @param oneline if true, the stats are returned in a single line, else they are returned in pretty format
+   *
    * @return a formatted string containing the statistics
    */
-  public String getRenderingStats() {
-    return nativeMapView.getRenderingStats();
+  public String getRenderingStats(boolean oneline) {
+    return nativeMapView.getRenderingStats(oneline);
   }
 
   public String getSnapshotCapture() {

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMap.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMap.java
@@ -290,7 +290,7 @@ interface NativeMap {
 
   boolean finalizeRoutes();
 
-  String getRenderingStats();
+  String getRenderingStats(boolean oneline);
 
   String getSnapshotCapture();
 

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
@@ -1224,8 +1224,8 @@ final class NativeMapView implements NativeMap {
   }
 
   @Override
-  public String getRenderingStats() {
-    return nativeGetRenderingStats();
+  public String getRenderingStats(boolean oneline) {
+    return nativeGetRenderingStats(oneline);
   }
 
   @Override
@@ -1712,7 +1712,7 @@ final class NativeMapView implements NativeMap {
   //---------------------------------------------------------
 
   @Keep
-  private native String nativeGetRenderingStats();
+  private native String nativeGetRenderingStats(boolean oneline);
 
   @Keep
   private native void nativeOnLowMemory();

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -752,7 +752,7 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
                 } break;
 
                 case GLFW_KEY_Q:
-                    view->writeStats();
+                    view->writeStats(true);
                     break;
 
                 case GLFW_KEY_0:
@@ -975,7 +975,7 @@ mbgl::Point<double> GLFWView::RouteCircle::getPoint(double percent) const {
     return points.back();
 }
 
-void GLFWView::writeStats() {
+void GLFWView::writeStats(bool oneline) const {
     std::stringstream ss;
     std::string renderingStats = backend->getRendererBackend().getRenderingStats().toJSONString();
     std::string routeStats = rmptr_->getStats();
@@ -999,7 +999,13 @@ void GLFWView::writeStats() {
     rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(buffer);
     combined.Accept(writer);
 
-    std::cout << buffer.GetString() << std::endl;
+    std::string jsonString = buffer.GetString();
+    if (oneline) {
+        jsonString.erase(std::remove(jsonString.begin(), jsonString.end(), '\n'), jsonString.end());
+        jsonString.erase(std::remove(jsonString.begin(), jsonString.end(), '\t'), jsonString.end());
+    }
+
+    std::cout << jsonString << std::endl;
 }
 
 std::vector<RouteID> GLFWView::getAllRoutes() const {

--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -188,7 +188,7 @@ private:
     void writeCapture(const std::string &capture, const std::string &capture_file_name) const;
     void readAndLoadCapture(const std::string &capture_file_name);
     int getCaptureIdx() const;
-    void writeStats();
+    void writeStats(bool oneline = false) const;
     std::vector<RouteID> getAllRoutes() const;
     std::string getBaseRouteLayerName(const RouteID &routeID) const;
     std::string getBaseGeoJSONsourceName(const RouteID &routeID) const;

--- a/src/mbgl/route/route_manager.cpp
+++ b/src/mbgl/route/route_manager.cpp
@@ -525,7 +525,8 @@ const std::string RouteManager::getStats() {
     route_stats.AddMember("avg_route_create_interval_seconds", stats_.avgRouteCreationInterval, allocator);
     route_stats.AddMember(
         "avg_route_segment_create_interval_seconds", stats_.avgRouteSegmentCreationInterval, allocator);
-
+    route_stats.AddMember("num_layers", style_->getLayers().size(), allocator);
+    route_stats.AddMember("num_sources", style_->getSources().size(), allocator);
     document.AddMember("route_stats", route_stats, allocator);
 
     rapidjson::StringBuffer buffer;


### PR DESCRIPTION
Issue: to easily parse the stats, the stats string is pressed into one line with no next lines or tabs. This is done so that integration team can easily read the string from logs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alproton/maplibre-native/14)
<!-- Reviewable:end -->
