### PR TITLE
Fix repeating onCameraMove

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/camera/CameraPosition.kt
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/camera/CameraPosition.kt
@@ -15,6 +15,7 @@ import org.maplibre.android.constants.MapLibreConstants
 import org.maplibre.android.geometry.LatLng
 import org.maplibre.android.utils.MathUtils
 import java.util.Arrays
+import kotlin.math.abs
 
 /**
  * Resembles the position, angle, zoom and tilt of the user's viewpoint.
@@ -143,6 +144,7 @@ class CameraPosition
      * Else, false.
      */
     override fun equals(other: Any?): Boolean {
+        val epsilon = 1e-5 // For zoom and degree angles 1e-5 is small enough
         if (this === other) {
             return true
         }
@@ -150,13 +152,13 @@ class CameraPosition
             return false
         }
         val cameraPosition = other as CameraPosition
-        if (target != null && target != cameraPosition.target) {
+        if (target != null && !target.equals(cameraPosition.target)) {
             return false
-        } else if (zoom != cameraPosition.zoom) {
+        } else if (abs(zoom - cameraPosition.zoom) > epsilon) {
             return false
-        } else if (tilt != cameraPosition.tilt) {
+        } else if (abs(tilt - cameraPosition.tilt) > epsilon) {
             return false
-        } else if (bearing != cameraPosition.bearing) {
+        } else if (abs(bearing - cameraPosition.bearing) > epsilon) {
             return false
         } else if (!Arrays.equals(padding, cameraPosition.padding)) {
             return false

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/geometry/LatLng.kt
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/geometry/LatLng.kt
@@ -171,7 +171,8 @@ class LatLng : Parcelable {
             return false
         }
         val latLng = other as LatLng
-        return java.lang.Double.compare(latLng.altitude, altitude) == 0 && java.lang.Double.compare(latLng.latitude, latitude) == 0 && java.lang.Double.compare(latLng.longitude, longitude) == 0
+        val epsilon = 1e-10 // This is much smaller than 1 millimeter
+        return abs(latLng.latitude - latitude) < epsilon && abs(latLng.longitude - longitude) < epsilon && abs(latLng.altitude - altitude) < epsilon
     }
 
     /**

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/Transform.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/Transform.java
@@ -172,7 +172,29 @@ public class Transform implements MapView.OnCameraDidChangeListener {
   }
 
   private boolean isValidCameraPosition(@Nullable CameraPosition cameraPosition) {
-    return cameraPosition != null && !cameraPosition.equals(this.cameraPosition);
+    double epsilon = 1e-5; // For zoom and degree angle comparisons 1e-5 is small enough
+    if (cameraPosition == null) {
+      return false;
+    }
+    if (this.cameraPosition == null) {
+      return true;
+    }
+    if (cameraPosition.zoom >= 0 && Math.abs(cameraPosition.zoom - this.cameraPosition.zoom) > epsilon) {
+      return true;
+    }
+    if (cameraPosition.tilt >= 0 && Math.abs(cameraPosition.tilt - this.cameraPosition.tilt) > epsilon) {
+      return true;
+    }
+    if (cameraPosition.bearing >= 0 && Math.abs(cameraPosition.bearing - this.cameraPosition.bearing) > epsilon) {
+      return true;
+    }
+    if (cameraPosition.target != null && !cameraPosition.target.equals(this.cameraPosition.target)) {
+      return true;
+    }
+    if (cameraPosition.padding != null && !cameraPosition.padding.equals(this.cameraPosition.padding)) {
+      return true;
+    }
+    return false;
   }
 
   @UiThread


### PR DESCRIPTION
Make sure we don't keep calling `onCameraMove` repeatedly even when the camera isn't moving by adding an epsilon when checking for Camera changes and also consider the fact that `CameraPosition.Builder` can build a camera with partially set parameters

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alproton/maplibre-native/21)
<!-- Reviewable:end -->
