### PR TITLE
Fix shutdown crash

### DIFF
--- a/include/mbgl/gfx/renderer_backend.hpp
+++ b/include/mbgl/gfx/renderer_backend.hpp
@@ -70,10 +70,6 @@ public:
 #endif
     const mbgl::util::SimpleIdentity uniqueID;
 
-    std::unique_ptr<gfx::CustomPuck> customPuck = nullptr;
-
-    std::unique_ptr<gfx::CustomDots> customDots = nullptr;
-
 protected:
     virtual std::unique_ptr<Context> createContext() = 0;
 
@@ -98,6 +94,10 @@ protected:
     TaggedScheduler threadPool;
 
     friend class BackendScope;
+
+public:
+    std::unique_ptr<gfx::CustomPuck> customPuck = nullptr;
+    std::unique_ptr<gfx::CustomDots> customDots = nullptr;
 };
 
 constexpr bool operator==(const RendererBackend& a, const RendererBackend& b) {


### PR DESCRIPTION
Order of destruction was wrong. Custom objects must be destroyed after the gl context because they call `glDeleteTexture`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alproton/maplibre-native/23)
<!-- Reviewable:end -->
