### PR TITLE
fixes for slerp

### DIFF
--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -127,7 +127,7 @@ private:
     void captureSnapshot();
     void setRouteProgressUsage();
     void setRoutePickMode();
-    void replayNavStops();
+    void scrubNavStops(bool forward);
 
     void cycleDebugOptions();
     void clearAnnotations();
@@ -207,6 +207,7 @@ private:
     bool generateRouteProgressPercent_ = false;
     bool routePickMode_ = false;
     bool captureNavPoints_ = true;
+    mbgl::route::Precision routePrecision_ = mbgl::route::Precision::Coarse;
 
     // Frame timer
     int frames = 0;


### PR DESCRIPTION
This PR adds the following:

* Normalize the incoming vector when converting cartesian coordinate to latlon.
* minor refactoring for glfw scrubbing captured nav stops replays

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alproton/maplibre-native/25)
<!-- Reviewable:end -->
