### PR TITLE
Support for route vanishing in render thread

### DIFF
--- a/include/mbgl/gfx/context.hpp
+++ b/include/mbgl/gfx/context.hpp
@@ -74,6 +74,8 @@ public:
     Context& operator=(const Context& other) = delete;
     virtual ~Context() = default;
 
+    virtual double getRouteVanishing() = 0;
+
     virtual void setObserver(ContextObserver* observer_) { observer = observer_ ? observer_ : &nullObserver; }
 
     virtual void beginFrame() = 0;

--- a/include/mbgl/gfx/context.hpp
+++ b/include/mbgl/gfx/context.hpp
@@ -188,6 +188,8 @@ public:
     // Remove the custom puck code when #3135 is resolved
     virtual std::unique_ptr<CustomPuck> createCustomPuck() { return nullptr; }
 
+    virtual std::optional<gfx::CustomPuckState> getCustomPuckState() const { return std::nullopt; }
+
     // Similar to custom puck, CustomDots should be replaced with CustomLayerV3
     // once texture atlas updates are optimized out
     virtual std::unique_ptr<CustomDots> createCustomDots() { return nullptr; }

--- a/include/mbgl/gfx/custom_puck.hpp
+++ b/include/mbgl/gfx/custom_puck.hpp
@@ -27,12 +27,12 @@ public:
 
     PremultipliedImage getPuckBitmap();
 
+    virtual CustomPuckState getState() = 0;
+
 protected:
     using ScreenQuad = std::array<ScreenCoordinate, 4>;
 
     virtual void drawImpl(const ScreenQuad&) = 0;
-
-    virtual CustomPuckState getState() = 0;
 
 private:
     PremultipliedImage bitmap{};

--- a/include/mbgl/gfx/renderer_backend.hpp
+++ b/include/mbgl/gfx/renderer_backend.hpp
@@ -8,6 +8,7 @@
 
 #include <memory>
 #include <mutex>
+#include <mbgl/route/route_manager.hpp>
 
 namespace mbgl {
 
@@ -41,7 +42,7 @@ public:
     TaggedScheduler& getThreadPool() noexcept { return threadPool; }
     /// Returns the device's context.
     Context& getContext();
-
+    virtual double getVanishingRoutePercent([[maybe_unused]] const Point<double> vaninshingPt) { return -1.0; }
     /**
      * @brief  this method is to be used when the context is needed outside of the rendering scope and should
      * be called only at such times. An example of this would be to get the RenderingStats from the context.
@@ -92,12 +93,14 @@ protected:
     const ContextMode contextMode;
     std::once_flag initialized;
     TaggedScheduler threadPool;
+    std::unique_ptr<mbgl::route::RouteManager> routeMgr;
 
     friend class BackendScope;
 
 public:
     std::unique_ptr<gfx::CustomPuck> customPuck = nullptr;
     std::unique_ptr<gfx::CustomDots> customDots = nullptr;
+    std::shared_ptr<route::RouteManager> routeManager = std::make_shared<route::RouteManager>();
 };
 
 constexpr bool operator==(const RendererBackend& a, const RendererBackend& b) {

--- a/include/mbgl/gl/renderer_backend.hpp
+++ b/include/mbgl/gl/renderer_backend.hpp
@@ -23,7 +23,7 @@ public:
     /// Called prior to rendering to update the internally assumed OpenGL state.
     virtual void updateAssumedState() = 0;
     mbgl::gfx::RenderingStats getRenderingStats() override;
-
+    double getVanishingRoutePercent(const Point<double> vaninshingPt) override;
 #if MLN_DRAWABLE_RENDERER
     /// One-time shader initialization
     void initShaders(gfx::ShaderRegistry&, const ProgramParameters& programParameters) override;

--- a/include/mbgl/route/route.hpp
+++ b/include/mbgl/route/route.hpp
@@ -48,7 +48,7 @@ public:
     double routeGetProgress() const;
     double getTotalDistance() const;
     double getProgressPercent(const Point<double>& queryPoint, const Precision& precision, bool capture = false);
-    Point<double> getPoint(double percent, const Precision& precision) const;
+    Point<double> getPoint(double percent, const Precision& precision, double* bearing = nullptr) const;
 
     mbgl::LineString<double> getGeometry() const;
     bool hasRouteSegments() const;
@@ -67,10 +67,11 @@ private:
     };
 
     std::vector<SegmentRange> compactSegments(const RouteType& routeType) const;
-    Point<double> getPointCoarse(double percent) const;
-    Point<double> getPointFine(double percent) const;
+    Point<double> getPointCoarse(double percent, double* bearing = nullptr) const;
+    Point<double> getPointFine(double percent, double* bearing = nullptr) const;
     double getProgressProjectionLERP(const Point<double>& queryPoint, bool capture = false);
     double getProgressProjectionSLERP(const Point<double>& queryPoint, bool capture = false);
+    std::optional<double> getVectorOrientation(double dx, double dy) const;
 
     RouteOptions routeOptions_;
     double progress_ = 0.0;

--- a/include/mbgl/route/route.hpp
+++ b/include/mbgl/route/route.hpp
@@ -80,7 +80,6 @@ private:
     mbgl::LineString<double> geometry_;
     std::map<double, mbgl::Color> segGradient_;
     double totalLength_ = 0.0;
-    uint32_t bestIntervalIndex_;
     std::vector<double> capturedNavPercent_;
     std::vector<Point<double>> capturedNavStops_;
     bool logPrecision = true;

--- a/include/mbgl/route/route_manager.hpp
+++ b/include/mbgl/route/route_manager.hpp
@@ -68,7 +68,10 @@ public:
                            const Point<double>& queryPoint,
                            const Precision& precision,
                            bool capture = false);
-    Point<double> getPoint(const RouteID& routeID, double percent, const Precision& precision) const;
+    Point<double> getPoint(const RouteID& routeID,
+                           double percent,
+                           const Precision& precision,
+                           double* bearing = nullptr) const;
     void routeClearSegments(const RouteID&);
     bool routeDispose(const RouteID&);
     bool setVanishingRouteID(const RouteID& routeID);

--- a/include/mbgl/route/route_manager.hpp
+++ b/include/mbgl/route/route_manager.hpp
@@ -67,6 +67,8 @@ public:
     Point<double> getPoint(const RouteID& routeID, double percent, const Precision& precision) const;
     void routeClearSegments(const RouteID&);
     bool routeDispose(const RouteID&);
+    bool setVanishingRouteID(const RouteID& routeID);
+    RouteID getVanishingRouteID() const;
     std::vector<RouteID> getAllRoutes() const;
     std::string getActiveRouteLayerName(const RouteID& routeID) const;
     std::string getBaseRouteLayerName(const RouteID& routeID) const;
@@ -105,6 +107,7 @@ private:
     // TODO: change this to weak reference
     style::Style* style_ = nullptr;
     std::unordered_map<RouteID, Route, IDHasher<RouteID>> routeMap_;
+    RouteID vanishingRouteID_;
 };
 }; // namespace route
 

--- a/include/mbgl/route/route_manager.hpp
+++ b/include/mbgl/route/route_manager.hpp
@@ -64,6 +64,10 @@ public:
                                  const Point<double>& progressPoint,
                                  const Precision& precision,
                                  bool capture = false);
+    double routeGetPercent(const RouteID& routeID,
+                           const Point<double>& queryPoint,
+                           const Precision& precision,
+                           bool capture = false);
     Point<double> getPoint(const RouteID& routeID, double percent, const Precision& precision) const;
     void routeClearSegments(const RouteID&);
     bool routeDispose(const RouteID&);

--- a/include/mbgl/style/layers/line_layer.hpp
+++ b/include/mbgl/style/layers/line_layer.hpp
@@ -122,6 +122,8 @@ public:
     const PropertyValue<Color>& getGradientLineClipColor() const;
 
 
+    void setClipLineEnable(bool enable);
+    bool getClipLineEnable() const;
     // Private implementation
 
     class Impl;

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -1588,10 +1588,12 @@ void NativeMapView::registerNative(jni::JNIEnv& env) {
         METHOD(&NativeMapView::routeProgressSetPoint, "nativeRouteSetProgressPoint"),
         METHOD(&NativeMapView::routeSegmentsClear, "nativeRouteClearSegments"),
         METHOD(&NativeMapView::routeSegmentCreate, "nativeRouteSegmentCreate"),
-        METHOD(&NativeMapView::getRenderingStats, "nativeGetRenderingStats"),
+        METHOD(&NativeMapView::routeSetVanishing, "nativeRouteSetVanishing"),
+        METHOD(&NativeMapView::routeGetVanishing, "nativeRouteGetVanishing"),
         METHOD(&NativeMapView::routeQueryRendered, "nativeRouteQuery"),
         METHOD(&NativeMapView::routesGetCaptureSnapshot, "nativeRoutesCaptureSnapshot"),
         METHOD(&NativeMapView::routesFinalize, "nativeRoutesFinalize"),
+        METHOD(&NativeMapView::getRenderingStats, "nativeGetRenderingStats"),
         // Custom Dots API
         METHOD(&NativeMapView::setCustomDotsNextLayer, "nativeSetCustomDotsNextLayer"),
         METHOD(&NativeMapView::setCustomDotsPoints, "nativeSetCustomDotsPoints"),
@@ -1768,6 +1770,22 @@ void NativeMapView::routeSegmentsClear(JNIEnv& env, jint routeID) {
     if (routeMgr) {
         routeMgr->routeClearSegments(RouteID(routeID));
     }
+}
+
+jboolean NativeMapView::routeSetVanishing(JNIEnv& env, jni::jint routeID) {
+    if (routeMgr) {
+        return routeMgr->setVanishingRouteID(RouteID(routeID));
+    }
+
+    return false;
+}
+
+jint NativeMapView::routeGetVanishing(JNIEnv& env) {
+    if (routeMgr) {
+        return routeMgr->getVanishingRouteID().id;
+    }
+
+    return -1;
 }
 
 jboolean NativeMapView::routesFinalize(JNIEnv& env) {

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
@@ -417,7 +417,7 @@ public:
 
 private:
     std::unique_ptr<AndroidRendererFrontend> rendererFrontend;
-    std::unique_ptr<mbgl::route::RouteManager> routeMgr;
+    std::shared_ptr<route::RouteManager> getRouteMgr();
 
     JavaVM* vm = nullptr;
     jni::WeakReference<jni::Object<NativeMapView>> javaPeer;

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
@@ -277,6 +277,10 @@ public:
     jint routeQueryRendered(JNIEnv& env, jni::jdouble screenSpaceX, jni::jdouble screenSpaceY, jni::jint radius);
 
     jboolean routesFinalize(JNIEnv& env);
+
+    jboolean routeSetVanishing(JNIEnv& env, jni::jint routeID);
+
+    jint routeGetVanishing(JNIEnv& env);
     //------------------------------------------------
 
     jni::Local<jni::String> getRenderingStats(JNIEnv& env, jni::jboolean oneline);

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapView.java
@@ -64,7 +64,6 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   private final MapChangeReceiver mapChangeReceiver = new MapChangeReceiver();
   private final MapCallback mapCallback = new MapCallback();
   private final InitialRenderCallback initialRenderCallback = new InitialRenderCallback();
-  private RouteID vanishingRouteID = new RouteID(-1);
   private boolean isPointBasedRouteQueryCoarse = true;
   private boolean isAutoRouteVanishing = true;
   private double latestRouteProgressPercent = 0.0;
@@ -535,7 +534,11 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
    * @param routeID the specified route ID for the corresponding route to vanish.
    */
   public void setVanishingRoute(RouteID routeID) {
-    vanishingRouteID = routeID;
+    nativeMapView.setVanishingRoute(routeID, true);
+  }
+
+  public RouteID getVanishingRouteID() {
+    return nativeMapView.getVanishingRoute();
   }
 
   /**
@@ -675,6 +678,8 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
                                  float iconScale,
                                  boolean cameraTracking) {
     mapRenderer.nativeSetCustomPuckState(lat, lon, bearing, iconScale, cameraTracking);
+    //TODO: this will be removed to render line layer
+    RouteID vanishingRouteID = getVanishingRouteID();
     if(isAutoRouteVanishing && vanishingRouteID.isValid()) {
       double percent = nativeMapView.setRouteProgressPoint(vanishingRouteID, Point.fromLngLat(lon, lat), isPointBasedRouteQueryCoarse, false);
       if(percent >= 0.0 && percent <= 1.0) {

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapView.java
@@ -678,19 +678,6 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
                                  float iconScale,
                                  boolean cameraTracking) {
     mapRenderer.nativeSetCustomPuckState(lat, lon, bearing, iconScale, cameraTracking);
-    //TODO: this will be removed to render line layer
-    RouteID vanishingRouteID = getVanishingRouteID();
-    if(isAutoRouteVanishing && vanishingRouteID.isValid()) {
-      double percent = nativeMapView.setRouteProgressPoint(vanishingRouteID, Point.fromLngLat(lon, lat), isPointBasedRouteQueryCoarse, false);
-      if(percent >= 0.0 && percent <= 1.0) {
-        nativeMapView.finalizeRoutes();
-        latestRouteProgressPercent = percent;
-      }
-
-      Timber.i("Map_View_Route_Progress: route percent: "+ percent);
-    } else {
-      Timber.i("Map_View_Route_Progress: invalid active route");
-    }
 
     customPuckLatestLat = lat;
     customPuckLatestLon = lon;

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapView.java
@@ -534,7 +534,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
    * @param routeID the specified route ID for the corresponding route to vanish.
    */
   public void setVanishingRoute(RouteID routeID) {
-    nativeMapView.setVanishingRoute(routeID, true);
+    nativeMapView.setVanishingRoute(routeID);
   }
 
   public RouteID getVanishingRouteID() {

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMap.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMap.java
@@ -290,7 +290,7 @@ interface NativeMap {
 
   void clearRouteSegments(RouteID routeID);
 
-  boolean setVanishingRoute(RouteID routeID, boolean vanishing);
+  boolean setVanishingRoute(RouteID routeID);
 
   RouteID getVanishingRoute();
 

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMap.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMap.java
@@ -290,6 +290,10 @@ interface NativeMap {
 
   void clearRouteSegments(RouteID routeID);
 
+  boolean setVanishingRoute(RouteID routeID, boolean vanishing);
+
+  RouteID getVanishingRoute();
+
   boolean finalizeRoutes();
 
   String getRenderingStats(boolean oneline);

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
@@ -1233,6 +1233,16 @@ final class NativeMapView implements NativeMap {
   }
 
   @Override
+  public boolean setVanishingRoute(RouteID routeID, boolean vanishing) {
+    return false;
+  }
+
+  @Override
+  public RouteID getVanishingRoute() {
+    return null;
+  }
+
+  @Override
   public boolean finalizeRoutes() {
     return nativeRoutesFinalize();
   }
@@ -1693,6 +1703,12 @@ final class NativeMapView implements NativeMap {
 
   @Keep
   private native String nativeRoutesCaptureSnapshot();
+
+  @Keep
+  private native boolean nativeRouteSetVanishing(int routeID, boolean vanishing);
+
+  @Keep
+  private native int nativeRouteGetVanishing();
 
   @Keep
   native void nativeRoutesClearStats();

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
@@ -1233,13 +1233,18 @@ final class NativeMapView implements NativeMap {
   }
 
   @Override
-  public boolean setVanishingRoute(RouteID routeID, boolean vanishing) {
+  public boolean setVanishingRoute(RouteID routeID) {
+    if(routeID.isValid()) {
+      return nativeRouteSetVanishing(routeID.getId());
+    }
+
     return false;
   }
 
   @Override
   public RouteID getVanishingRoute() {
-    return null;
+    int routeID = nativeRouteGetVanishing();
+    return new RouteID(routeID);
   }
 
   @Override
@@ -1705,7 +1710,7 @@ final class NativeMapView implements NativeMap {
   private native String nativeRoutesCaptureSnapshot();
 
   @Keep
-  private native boolean nativeRouteSetVanishing(int routeID, boolean vanishing);
+  private native boolean nativeRouteSetVanishing(int routeID);
 
   @Keep
   private native int nativeRouteGetVanishing();

--- a/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/routes/RouteActivity.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/routes/RouteActivity.kt
@@ -22,6 +22,7 @@ import org.maplibre.android.location.permissions.PermissionsManager
 import org.maplibre.android.maps.MapLibreMap
 import org.maplibre.android.maps.MapView
 import org.maplibre.android.maps.OnMapReadyCallback
+import org.maplibre.android.maps.RouteID
 import org.maplibre.android.maps.Style
 import org.maplibre.android.testapp.R
 import org.maplibre.android.testapp.utils.ApiKeyUtils
@@ -35,6 +36,8 @@ class RouteActivity : AppCompatActivity(), OnMapReadyCallback {
     private val useLocationEngine = false
     private var permissionsManager: PermissionsManager? = null
     private var locationManager : LocationManager? = null
+    private val enableAutoRouteVanishing = true
+    private var vanishingRouteID : RouteID = RouteID(-1)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -45,7 +48,8 @@ class RouteActivity : AppCompatActivity(), OnMapReadyCallback {
         mapView = findViewById(R.id.mapView)
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync(this)
-        mapView.setAutoVanishingRoute(false)
+        mapView.setAutoVanishingRoute(enableAutoRouteVanishing)
+        mapView.setCustomPuckState(0.0, 0.0, 0.0, 1.0f, false)
 
         //Add route
         val addRouteButton = findViewById<Button>(R.id.add_route)
@@ -131,13 +135,17 @@ class RouteActivity : AppCompatActivity(), OnMapReadyCallback {
             override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
                 var progressPercent = progress.toDouble() / 100.0
 
-                if(progressModePoint) {
-                    RouteUtils.setPointProgress(mapView, progressPercent, progressPrecisionCoarse)
-                } else {
-                    RouteUtils.setPercentProgress(mapView, progressPercent)
-                }
+                if(enableAutoRouteVanishing) {
 
-                mapView.finalizeRoutes()
+                } else {
+                    if(progressModePoint) {
+                        RouteUtils.setPointProgress(mapView, progressPercent, progressPrecisionCoarse)
+                    } else {
+                        RouteUtils.setPercentProgress(mapView, progressPercent)
+                    }
+
+                    mapView.finalizeRoutes()
+                }
             }
 
             override fun onStartTrackingTouch(seekBar: SeekBar?) {}
@@ -236,11 +244,6 @@ class RouteActivity : AppCompatActivity(), OnMapReadyCallback {
             }
         }
 
-        //TODO: investigate and fix location component to programmatically set puck location
-//        val location : Location = Location("dummyprovider")
-//        location.latitude = 0.0
-//        location.longitude = 0.0
-//        maplibreMap.locationComponent.forceLocationUpdate(location)
 
     }
 

--- a/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/routes/RouteUtils.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/routes/RouteUtils.kt
@@ -151,6 +151,8 @@ class RouteUtils {
 
         }
 
+
+
         fun setPercentProgress(mapView: MapView, percent: Double) {
             val routeID = routeMap.keys.first()
             val routeCircle = routeMap[routeID]

--- a/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/routes/RouteUtils.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/routes/RouteUtils.kt
@@ -81,7 +81,7 @@ class RouteUtils {
             if (routeMap.isEmpty()) return
 
             val firstRouteID : RouteID = routeMap.keys.first()
-            if(firstRouteID.isValid()) {
+            if(firstRouteID.isValid) {
                 mapView.disposeRoute(firstRouteID)
             }
             routeMap.remove(firstRouteID)
@@ -146,12 +146,14 @@ class RouteUtils {
             Timber.tag("RouteProgress").i("getPoint: $point")
             val calculatedPercent = mapView.setRouteProgressPoint(routeID, point, progressPrecisionCoarse, false)
             Timber.tag("RouteProgress").i("inputPercent: $progress , calculatedPercent: $calculatedPercent")
-
-//            mapView.setCustomPuckState(point.latitude(), point.longitude(), 0.0, 1.0f, false)
-
         }
 
+        fun getPointProgress(progress: Double) : Point {
+            val routeID = routeMap.keys.first()
+            val routeCircle = routeMap[routeID]
 
+            return routeCircle?.getPoint(progress)!!
+        }
 
         fun setPercentProgress(mapView: MapView, percent: Double) {
             val routeID = routeMap.keys.first()
@@ -178,6 +180,10 @@ class RouteUtils {
 
             val routeID = mapView.createRoute(routeGeometry, routeOptions)
             mapView.finalizeRoutes()
+            //set the first routeID as the vanishing route
+            if  (routeMap.isEmpty()) {
+                mapView.setVanishingRoute(routeID)
+            }
             routeMap[routeID] = routeCircle
 
             addTrafficSegments(routeID, mapView)

--- a/platform/glfw/glfw_backend.hpp
+++ b/platform/glfw/glfw_backend.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "mbgl/gfx/custom_puck.hpp"
+
 #include <mbgl/util/size.hpp>
 #include <mbgl/gfx/backend.hpp>
 
@@ -17,6 +19,10 @@ public:
     GLFWBackend(const GLFWBackend&) = delete;
     GLFWBackend& operator=(const GLFWBackend&) = delete;
     virtual ~GLFWBackend() = default;
+    virtual void setCustomPuckState([[maybe_unused]] double lat,
+                                    [[maybe_unused]] double lon,
+                                    [[maybe_unused]] double bearing) {};
+    virtual void enableCustomPuck([[maybe_unused]] bool onOff) {};
 
     static std::unique_ptr<GLFWBackend> Create(GLFWwindow* window, bool capFrameRate) {
         return mbgl::gfx::Backend::Create<GLFWBackend, GLFWwindow*, bool>(window, capFrameRate);

--- a/platform/glfw/glfw_gl_backend.cpp
+++ b/platform/glfw/glfw_gl_backend.cpp
@@ -1,5 +1,7 @@
 #include "glfw_gl_backend.hpp"
 
+#include "mbgl/util/io.hpp"
+
 #include <mbgl/gfx/backend_scope.hpp>
 #include <mbgl/gl/renderable_resource.hpp>
 #include <mbgl/util/instrumentation.hpp>
@@ -51,6 +53,25 @@ GLFWGLBackend::GLFWGLBackend(GLFWwindow* window_, const bool capFrameRate)
 }
 
 GLFWGLBackend::~GLFWGLBackend() = default;
+
+mbgl::gfx::CustomPuckState GLFWGLBackend::getCurrentCustomPuckState() const {
+    return customPuckState_;
+}
+
+void GLFWGLBackend::setCustomPuckState(double lat, double lon, double bearing) {
+    customPuckState_.lat = lat;
+    customPuckState_.lon = lon;
+    customPuckState_.bearing = bearing;
+};
+
+void GLFWGLBackend::enableCustomPuck(bool onOff) {
+    customPuckState_.enabled = onOff;
+    customPuckState_.cameraTracking = false;
+    customPuckState_.bearing = 0;
+    if (onOff) {
+        customPuck->setPuckBitmap(mbgl::decodeImage(mbgl::util::read_file("../../../platform/glfw/assets/puck.png")));
+    }
+};
 
 void GLFWGLBackend::activate() {
     MLN_TRACE_FUNC();

--- a/platform/glfw/glfw_gl_backend.hpp
+++ b/platform/glfw/glfw_gl_backend.hpp
@@ -23,10 +23,15 @@ public:
     // mbgl::gfx::RendererBackend implementation
 public:
     mbgl::gfx::Renderable& getDefaultRenderable() override { return *this; }
+    virtual mbgl::gfx::CustomPuckState getCurrentCustomPuckState() const override;
+    virtual void setCustomPuckState(double lat, double lon, double bearing) override;
+    virtual void enableCustomPuck(bool onOff) override;
 
 protected:
     void activate() override;
     void deactivate() override;
+
+    mbgl::gfx::CustomPuckState customPuckState_;
 
     // mbgl::gl::RendererBackend implementation
 protected:

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -761,8 +761,12 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
                     view->writeStats(true);
                     break;
 
-                case GLFW_KEY_0:
-                    view->replayNavStops();
+                case GLFW_KEY_X:
+                    view->scrubNavStops(false);
+                    break;
+
+                case GLFW_KEY_C:
+                    view->scrubNavStops(true);
                     break;
             }
         } else {
@@ -1617,32 +1621,40 @@ void GLFWView::readAndLoadCapture(const std::string &capture_file_name) {
     }
 }
 
-void GLFWView::replayNavStops() {
+void GLFWView::scrubNavStops(bool forward) {
     if (loadedCapture_ && firstRouteID_.isValid()) {
+        if (forward) {
+            ++lastNavStop_;
+        } else {
+            --lastNavStop_;
+        }
         if (capturedNavStopMap_.find(firstRouteID_) != capturedNavStopMap_.end()) {
             const mbgl::LineString<double> &navstops = capturedNavStopMap_[firstRouteID_];
             const uint32_t sz = navstops.size();
-            const auto &navStop = navstops[lastNavStop_++ % sz];
-            double percentage = rmptr_->routeSetProgressPoint(firstRouteID_, navStop, mbgl::route::Precision::Coarse);
+            const auto &navStop = navstops[lastNavStop_ % sz];
+            double percentage = rmptr_->routeSetProgressPoint(firstRouteID_, navStop, routePrecision_);
             rmptr_->finalize();
-            std::cout << "replayNavStop - Route: " << firstRouteID_.id << ", NavStop: " << navStop.x << ", "
-                      << navStop.y << ", percent: " << std::to_string(percentage) << std::endl;
+            std::cout << "percent: " << std::to_string(percentage) << std::endl;
         } else if (capturedNavPercentMap_.find(firstRouteID_) != capturedNavPercentMap_.end()) {
             const auto &navstops = capturedNavPercentMap_[firstRouteID_];
             const uint32_t sz = navstops.size();
-            const double percent = navstops[lastNavStop_++ % sz];
+            const double percent = navstops[lastNavStop_ % sz];
             rmptr_->routeSetProgressPercent(firstRouteID_, percent);
             rmptr_->finalize();
         }
     } else if (loadedCapture_) {
         // perhaps the capture file did not have nav stops, lets just pick the first route we see and traverse it.
         if (!routeMap_.empty()) {
+            if (forward) {
+                routeProgress_ += ROUTE_PROGRESS_STEP;
+            } else {
+                routeProgress_ -= ROUTE_PROGRESS_STEP;
+            }
             const auto &routeID = routeMap_.begin()->first;
-            routeProgress_ += ROUTE_PROGRESS_STEP;
             routeProgress_ = std::clamp<double>(routeProgress_, 0.0, 1.0f);
-            const auto &navstop = rmptr_->getPoint(routeID, routeProgress_, mbgl::route::Precision::Coarse);
-            double percentage = rmptr_->routeSetProgressPoint(routeID, navstop, mbgl::route::Precision::Coarse);
-            std::cout << "replayNavStop - Route: " << routeID.id << ", i/p %: " << std::to_string(routeProgress_)
+            const auto &navstop = rmptr_->getPoint(routeID, routeProgress_, routePrecision_);
+            double percentage = rmptr_->routeSetProgressPoint(routeID, navstop, routePrecision_);
+            std::cout << ", ip %: " << std::to_string(routeProgress_)
                       << ", calculated %: " << std::to_string(percentage) << std::endl;
 
             rmptr_->finalize();

--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -201,7 +201,7 @@ private:
     std::unordered_map<RouteID, std::vector<double>, IDHasher<RouteID>> capturedNavPercentMap_;
     int lastCaptureIdx_ = 0;
     uint32_t lastNavStop_ = 0;
-    RouteID firstRouteID_;
+    RouteID vanishingRouteID_;
     bool loadedCapture_ = false;
     double routeProgress_ = 0.0;
     bool generateRouteProgressPercent_ = false;

--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -117,6 +117,8 @@ private:
     std::vector<RouteID> routeIDlist;
     std::unique_ptr<mbgl::route::RouteManager> rmptr_;
     void addRoute();
+    void enablePuck(bool onOff);
+    void setPuckLocation(double lat, double lon, double bearing);
     void modifyRoute();
     void disposeRoute();
     void addTrafficSegments();
@@ -125,7 +127,6 @@ private:
     void incrementRouteProgress();
     void decrementRouteProgress();
     void captureSnapshot();
-    void setRouteProgressUsage();
     void setRoutePickMode();
     void scrubNavStops(bool forward);
 
@@ -204,9 +205,9 @@ private:
     RouteID vanishingRouteID_;
     bool loadedCapture_ = false;
     double routeProgress_ = 0.0;
-    bool generateRouteProgressPercent_ = false;
     bool routePickMode_ = false;
     bool captureNavPoints_ = true;
+    bool enableAutoVanishing = true;
     mbgl::route::Precision routePrecision_ = mbgl::route::Precision::Coarse;
 
     // Frame timer

--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -40,6 +40,8 @@ public:
              const mbgl::ClientOptions &clientOptions);
     ~GLFWView() override;
 
+    std::shared_ptr<mbgl::route::RouteManager> getRouteMgr() const;
+
     float getPixelRatio() const;
 
     void setMap(mbgl::Map *);
@@ -115,7 +117,6 @@ private:
     void toggleCustomSource();
     void toggleLocationIndicatorLayer();
     std::vector<RouteID> routeIDlist;
-    std::unique_ptr<mbgl::route::RouteManager> rmptr_;
     void addRoute();
     void enablePuck(bool onOff);
     void setPuckLocation(double lat, double lon, double bearing);

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -280,6 +280,14 @@ std::unique_ptr<gfx::CustomPuck> Context::createCustomPuck() {
     return std::make_unique<gl::CustomPuck>(*this);
 }
 
+std::optional<gfx::CustomPuckState> Context::getCustomPuckState() const {
+    if (backend.customPuck) {
+        return std::make_optional<gfx::CustomPuckState>(backend.customPuck->getState());
+    }
+
+    return std::nullopt;
+}
+
 std::unique_ptr<gfx::CustomDots> Context::createCustomDots() {
     return std::make_unique<gl::CustomDots>(*this);
 }

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -33,6 +33,7 @@
 
 #include <cstring>
 #include <iterator>
+#include <boost/fusion/mpl/back.hpp>
 
 namespace mbgl {
 namespace gl {
@@ -281,6 +282,17 @@ std::unique_ptr<gfx::CustomPuck> Context::createCustomPuck() {
 
 std::unique_ptr<gfx::CustomDots> Context::createCustomDots() {
     return std::make_unique<gl::CustomDots>(*this);
+}
+
+double Context::getRouteVanishing() {
+    if (backend.customPuck != nullptr) {
+        double lat = backend.customPuck->getState().lat;
+        double lon = backend.customPuck->getState().lon;
+        mbgl::Point<double> vanishingPt = {lon, lat};
+        return backend.getVanishingRoutePercent(vanishingPt);
+    }
+
+    return -1.0;
 }
 
 UniqueTexture Context::createUniqueTexture(const Size& size,

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -169,6 +169,7 @@ public:
 
     std::unique_ptr<gfx::CustomPuck> createCustomPuck() override;
     std::unique_ptr<gfx::CustomDots> createCustomDots() override;
+    double getRouteVanishing() override;
 
 private:
     RendererBackend& backend;

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -168,6 +168,7 @@ public:
     RendererBackend& getBackend() { return backend; }
 
     std::unique_ptr<gfx::CustomPuck> createCustomPuck() override;
+    std::optional<gfx::CustomPuckState> getCustomPuckState() const override;
     std::unique_ptr<gfx::CustomDots> createCustomDots() override;
     double getRouteVanishing() override;
 

--- a/src/mbgl/gl/renderer_backend.cpp
+++ b/src/mbgl/gl/renderer_backend.cpp
@@ -32,6 +32,11 @@ std::unique_ptr<gfx::Context> RendererBackend::createContext() {
     return result;
 }
 
+double RendererBackend::getVanishingRoutePercent(const Point<double> vanishingPt) {
+    RouteID vanishingRouteID = routeManager->getVanishingRouteID();
+    return routeManager->routeGetPercent(vanishingRouteID, vanishingPt, route::Precision::Coarse, false);
+}
+
 PremultipliedImage RendererBackend::readFramebuffer(const Size& size) {
     MLN_TRACE_FUNC();
 

--- a/src/mbgl/gl/renderer_backend.cpp
+++ b/src/mbgl/gl/renderer_backend.cpp
@@ -34,7 +34,11 @@ std::unique_ptr<gfx::Context> RendererBackend::createContext() {
 
 double RendererBackend::getVanishingRoutePercent(const Point<double> vanishingPt) {
     RouteID vanishingRouteID = routeManager->getVanishingRouteID();
-    return routeManager->routeGetPercent(vanishingRouteID, vanishingPt, route::Precision::Coarse, false);
+    if (vanishingRouteID.isValid()) {
+        return routeManager->routeGetPercent(vanishingRouteID, vanishingPt, route::Precision::Coarse, false);
+    }
+
+    return -1.0;
 }
 
 PremultipliedImage RendererBackend::readFramebuffer(const Size& size) {

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -608,7 +608,9 @@ void RenderLineLayer::update(gfx::ShaderRegistry& shaders,
             if (layerTweaker) {
                 LineLayerTweakerPtr lineLayerTweaker = std::static_pointer_cast<LineLayerTweaker>(layerTweaker);
                 double currLineClip = context.getRouteVanishing();
-                lineLayerTweaker->setGradientLineClip(currLineClip);
+                if (currLineClip >= 0.0 && currLineClip <= 1.0) {
+                    lineLayerTweaker->setGradientLineClip(currLineClip);
+                }
             }
 
             const auto& currLineClipColor = impl_cast(baseImpl).paint.get<LineClipColor>().value;

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -377,6 +377,12 @@ void RenderLineLayer::update(gfx::ShaderRegistry& shaders,
         return;
     }
 
+    bool isClipLineEnabled = impl_cast(baseImpl).clipLineEnable;
+    std::string idstr = impl_cast(baseImpl).id;
+    std::string clipEnabledStr = isClipLineEnabled ? "true" : "false";
+    std::string msg = "layer for vanishing route: " + clipEnabledStr + ", " + idstr;
+    mbgl::Log::Info(mbgl::Event::Route, msg);
+
     // Set up a layer group
     if (!layerGroup) {
         if (auto layerGroup_ = context.createTileLayerGroup(layerIndex, /*initialCapacity=*/64, getID())) {

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -597,14 +597,20 @@ void RenderLineLayer::update(gfx::ShaderRegistry& shaders,
                 }
             }
 
-            const auto& currLineClipProp = impl_cast(baseImpl).paint.get<LineClip>().value;
-            if (currLineClipProp.isConstant()) {
-                double currLineClipPropValue = currLineClipProp.asConstant();
-                if (layerTweaker) {
-                    LineLayerTweakerPtr lineLayerTweaker = std::static_pointer_cast<LineLayerTweaker>(layerTweaker);
-                    lineLayerTweaker->setGradientLineClip(currLineClipPropValue);
-                }
+            // const auto& currLineClipProp = impl_cast(baseImpl).paint.get<LineClip>().value;
+            // if (currLineClipProp.isConstant()) {
+            //     double currLineClipPropValue = currLineClipProp.asConstant();
+            //     if (layerTweaker) {
+            //         LineLayerTweakerPtr lineLayerTweaker = std::static_pointer_cast<LineLayerTweaker>(layerTweaker);
+            //         lineLayerTweaker->setGradientLineClip(currLineClipPropValue);
+            //     }
+            // }
+            if (layerTweaker) {
+                LineLayerTweakerPtr lineLayerTweaker = std::static_pointer_cast<LineLayerTweaker>(layerTweaker);
+                double currLineClip = context.getRouteVanishing();
+                lineLayerTweaker->setGradientLineClip(currLineClip);
             }
+
             const auto& currLineClipColor = impl_cast(baseImpl).paint.get<LineClipColor>().value;
             if (currLineClipColor.isConstant()) {
                 Color currLineClipColorValue = currLineClipColor.asConstant();

--- a/src/mbgl/route/route.cpp
+++ b/src/mbgl/route/route.cpp
@@ -137,8 +137,7 @@ Point<double> cartesianToLatLon(const Vector3D& v) {
 
 Route::Route(const LineString<double>& geometry, const RouteOptions& ropts)
     : routeOptions_(ropts),
-      geometry_(geometry),
-      bestIntervalIndex_(INVALID_UINT) {
+      geometry_(geometry) {
     assert(!geometry_.empty() && "route geometry cannot be empty");
     assert((!std::isnan(geometry_[0].x) && !std::isnan(geometry_[0].y)) && "invalid geometry point");
 
@@ -604,24 +603,7 @@ double Route::getProgressProjectionLERP(const Point<double>& queryPoint, bool ca
     };
 
     // closestInterval.first is the interval index, closestInterval.second is the fraction along the interval
-    std::pair<uint32_t, double> closestInterval = {INVALID_UINT, -1.0};
-
-    // lets cache the best interval index, check if there is closest projection before, current and in the after
-    // interval.
-    if (bestIntervalIndex_ != INVALID_UINT) {
-        uint32_t startIdx = bestIntervalIndex_ == 0 ? 0 : bestIntervalIndex_ - 1;
-        uint32_t endIdx = bestIntervalIndex_ == geometry_.size() - 2 ? geometry_.size() - 1 : bestIntervalIndex_ + 1;
-        closestInterval = getClosestInterval(startIdx, endIdx);
-    }
-
-    // check if we have a valid closest interval, if not search throught the whole route
-    if (closestInterval.first == INVALID_UINT) {
-        closestInterval = getClosestInterval(0, geometry_.size() - 1);
-    }
-
-    assert(closestInterval.first != INVALID_UINT && "Invalid best interval index");
-    assert(closestInterval.second >= 0.0 && closestInterval.second <= 1.0 && "Invalid best interval fraction");
-    bestIntervalIndex_ = closestInterval.first;
+    std::pair<uint32_t, double> closestInterval = getClosestInterval(0, geometry_.size() - 1);
 
     // --- Calculate final percentage ---
     uint32_t bestIntervalIndex = closestInterval.first;

--- a/src/mbgl/route/route_manager.cpp
+++ b/src/mbgl/route/route_manager.cpp
@@ -24,6 +24,7 @@
 #include <chrono>
 #include <iomanip> // For formatting
 #include <iterator>
+#include <iostream>
 
 namespace mbgl {
 namespace route {
@@ -569,10 +570,13 @@ double RouteManager::routeGetPercent(const RouteID& routeID,
     return percentage;
 }
 
-mbgl::Point<double> RouteManager::getPoint(const RouteID& routeID, double percent, const Precision& precision) const {
+mbgl::Point<double> RouteManager::getPoint(const RouteID& routeID,
+                                           double percent,
+                                           const Precision& precision,
+                                           double* bearing) const {
     assert(routeID.isValid() && "invalid route ID");
     if (routeID.isValid() && routeMap_.find(routeID) != routeMap_.end()) {
-        return routeMap_.at(routeID).getPoint(percent, precision);
+        return routeMap_.at(routeID).getPoint(percent, precision, bearing);
     }
 
     return {0.0, 0.0};

--- a/src/mbgl/route/route_manager.cpp
+++ b/src/mbgl/route/route_manager.cpp
@@ -819,6 +819,36 @@ void RouteManager::finalizeRoute(const RouteID& routeID, const DirtyType& dt) {
     }
 }
 
+bool RouteManager::setVanishingRouteID(const RouteID& routeID) {
+    bool success = false;
+    if (routeID.isValid() && routeMap_.find(routeID) != routeMap_.end() && style_ != nullptr) {
+        // iterate through all the route layers and set the layer is a vanishing route layer
+        vanishingRouteID_ = routeID;
+        const auto& routes = getAllRoutes();
+        for (const RouteID& currRouteID : routes) {
+            std::string baseLayerName = getBaseRouteLayerName(currRouteID);
+            std::string activeLayerName = getActiveRouteLayerName(currRouteID);
+
+            bool enableVanishingRoute = currRouteID == vanishingRouteID_;
+            if (style_->getLayer(baseLayerName) != nullptr) {
+                style::LineLayer* linelayer = static_cast<style::LineLayer*>(style_->getLayer(baseLayerName));
+                linelayer->setClipLineEnable(enableVanishingRoute);
+            }
+            if (style_->getLayer(activeLayerName) != nullptr) {
+                style::LineLayer* linelayer = static_cast<style::LineLayer*>(style_->getLayer(activeLayerName));
+                linelayer->setClipLineEnable(enableVanishingRoute);
+            }
+        }
+        success = true;
+    }
+
+    return success;
+}
+
+RouteID RouteManager::getVanishingRouteID() const {
+    return vanishingRouteID_;
+}
+
 void RouteManager::finalize() {
     using namespace mbgl::style;
     using namespace mbgl::style::expression;

--- a/src/mbgl/route/route_manager.cpp
+++ b/src/mbgl/route/route_manager.cpp
@@ -556,6 +556,19 @@ double RouteManager::routeSetProgressPoint(const RouteID& routeID,
     return percentage;
 }
 
+double RouteManager::routeGetPercent(const RouteID& routeID,
+                                     const Point<double>& queryPoint,
+                                     const Precision& precision,
+                                     bool capture) {
+    assert(routeID.isValid() && "invalid route ID");
+    double percentage = -1.0;
+    if (routeID.isValid() && routeMap_.find(routeID) != routeMap_.end()) {
+        percentage = routeMap_.at(routeID).getProgressPercent(queryPoint, precision, capture);
+    }
+
+    return percentage;
+}
+
 mbgl::Point<double> RouteManager::getPoint(const RouteID& routeID, double percent, const Precision& precision) const {
     assert(routeID.isValid() && "invalid route ID");
     if (routeID.isValid() && routeMap_.find(routeID) != routeMap_.end()) {

--- a/src/mbgl/style/layers/line_layer.cpp
+++ b/src/mbgl/style/layers/line_layer.cpp
@@ -482,6 +482,18 @@ const PropertyValue<Color>& LineLayer::getGradientLineClipColor() const {
     return impl().paint.template get<LineClipColor>().value;
 }
 
+void LineLayer::setClipLineEnable(bool enable) {
+    auto impl_ = mutableImpl();
+    impl_->clipLineEnable = enable;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+bool LineLayer::getClipLineEnable() const {
+    return mutableImpl()->clipLineEnable;
+}
+
+
 using namespace conversion;
 
 namespace {

--- a/src/mbgl/style/layers/line_layer_impl.hpp
+++ b/src/mbgl/style/layers/line_layer_impl.hpp
@@ -21,6 +21,7 @@ public:
     LineLayoutProperties::Unevaluated layout;
     LinePaintProperties::Transitionable paint;
     LineGradientFilterType gradientFilterType = LineGradientFilterType::Linear;
+    bool clipLineEnable = false;
 
     DECLARE_LAYER_TYPE_INFO;
 };


### PR DESCRIPTION
This PR does quite a bit of refactoring in order to compute % progress in the render thread for higher frequency invocation of vanishing. This is broken up into the following steps:

1) Introduce a non property boolean in LineLayer for RenderLineLayer to know it is for used by a route.
2) Move route manager to Renderer Backend instead of it being in native map view. This is so that we can access the method to compute the vanishing percentage from Context available during Renderer's render ().
3) Expose APIs to set the vanishing RouteID and get the same.
4) VanishingRouteID is removed from MapView.java and is now maintained in RouteManager
5) Implement RenderLineLayer's update method to now always check for existance of a vanishingRouteID in the RouteManager and if so, pass CustomPuckState's location to get back a %.
6) Update all examples - GLFW and Android example
