### PR TITLE
Fix a crash related to rendering the puck before the style is loaded

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationAnimatorCustomPuck.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationAnimatorCustomPuck.java
@@ -102,6 +102,14 @@ final class LocationAnimatorCustomPuck {
           targetPuckLocation = new StampedLatLon(currentPuckLocation);
         }
 
+        // Make sure the style is loaded before rendering the puck
+        if (mapView == null
+            || mapView.getMapLibreMap() == null
+            || mapView.getMapLibreMap().getStyle() == null
+            || !mapView.getMapLibreMap().getStyle().isFullyLoaded()) {
+          return;
+        }
+
         // Get a handler that can be used to post to the main thread
         Handler mainHandler = new Handler(context.getMainLooper());
 


### PR DESCRIPTION
Check the style is loaded `style.isFullyLoaded()` is `true` before rendering the puck. This avoids a rare crash similar to #3348

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alproton/maplibre-native/30)
<!-- Reviewable:end -->
