### PR TITLE
Miscellaneous work on route rendering

### DIFF
--- a/include/mbgl/route/route.hpp
+++ b/include/mbgl/route/route.hpp
@@ -48,7 +48,7 @@ public:
     double routeGetProgress() const;
     double getTotalDistance() const;
     double getProgressPercent(const Point<double>& queryPoint, const Precision& precision, bool capture = false);
-    Point<double> getPoint(double percent, const Precision& precision) const;
+    Point<double> getPoint(double percent, const Precision& precision, double* bearing = nullptr) const;
 
     mbgl::LineString<double> getGeometry() const;
     bool hasRouteSegments() const;
@@ -57,6 +57,7 @@ public:
     uint32_t getNumRouteSegments() const;
     const std::vector<Point<double>>& getCapturedNavStops() const;
     const std::vector<double>& getCapturedNavPercent() const;
+    static std::optional<double> getVectorOrientation(double x, double y);
 
     std::string segmentsToString(uint32_t tabcount) const;
 
@@ -67,8 +68,8 @@ private:
     };
 
     std::vector<SegmentRange> compactSegments(const RouteType& routeType) const;
-    Point<double> getPointCoarse(double percent) const;
-    Point<double> getPointFine(double percent) const;
+    Point<double> getPointCoarse(double percent, double* bearing = nullptr) const;
+    Point<double> getPointFine(double percent, double* bearing = nullptr) const;
     double getProgressProjectionLERP(const Point<double>& queryPoint, bool capture = false);
     double getProgressProjectionSLERP(const Point<double>& queryPoint, bool capture = false);
 

--- a/include/mbgl/route/route_manager.hpp
+++ b/include/mbgl/route/route_manager.hpp
@@ -25,6 +25,9 @@ struct RouteMgrStats {
     bool inconsistentAPIusage = false;
     double avgRouteCreationInterval = 0.0;
     double avgRouteSegmentCreationInterval = 0.0;
+    long long maxRouteVanishingElapsedMillis = 0.0;
+    long long minRouteVanishingElapsedMillis = 0.0;
+    double avgRouteVanishingElapsedMillis = 0.0;
 };
 
 /***
@@ -111,6 +114,8 @@ private:
     style::Style* style_ = nullptr;
     std::unordered_map<RouteID, Route, IDHasher<RouteID>> routeMap_;
     RouteID vanishingRouteID_;
+    long long totalVanishingRouteElapsedMillis = 0;
+    long long numVanisingRouteInvocations = 0;
 };
 }; // namespace route
 

--- a/include/mbgl/route/route_manager.hpp
+++ b/include/mbgl/route/route_manager.hpp
@@ -64,9 +64,14 @@ public:
                                  const Point<double>& progressPoint,
                                  const Precision& precision,
                                  bool capture = false);
-    Point<double> getPoint(const RouteID& routeID, double percent, const Precision& precision) const;
+    Point<double> getPoint(const RouteID& routeID,
+                           double percent,
+                           const Precision& precision,
+                           double* bearing = nullptr) const;
     void routeClearSegments(const RouteID&);
     bool routeDispose(const RouteID&);
+    bool setVanishingRouteID(const RouteID& routeID);
+    RouteID getVanishingRouteID() const;
     std::vector<RouteID> getAllRoutes() const;
     std::string getActiveRouteLayerName(const RouteID& routeID) const;
     std::string getBaseRouteLayerName(const RouteID& routeID) const;
@@ -105,6 +110,7 @@ private:
     // TODO: change this to weak reference
     style::Style* style_ = nullptr;
     std::unordered_map<RouteID, Route, IDHasher<RouteID>> routeMap_;
+    RouteID vanishingRouteID_;
 };
 }; // namespace route
 

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -1731,6 +1731,7 @@ jboolean NativeMapView::routeSegmentCreate(JNIEnv& env,
         Result<Color> innerSegmentColorRes = colorConverter(env, color);
         if (innerSegmentColorRes) {
             rsegopts.color = *innerSegmentColorRes;
+            rsegopts.color.a = 1.0f;
         }
 
         Result<Color> outerSegmentColorRes = colorConverter(env, outerColor);

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -1652,16 +1652,20 @@ jint NativeMapView::routeCreate(JNIEnv& env,
             Result<Color> outerClipColorRes = colorConverter(env, outerClipColor);
             Result<Color> innerClipColorRes = colorConverter(env, innerClipColor);
             if (outerColorRes) {
-                routeOptions.outerColor = *outerColorRes;
+                mbgl::Color ocolor = *outerColorRes;
+                routeOptions.outerColor = {ocolor.r, ocolor.g, ocolor.b, 1.0f};
             }
             if (innerColorRes) {
-                routeOptions.innerColor = *innerColorRes;
+                mbgl::Color icolor = *innerColorRes;
+                routeOptions.innerColor = {icolor.r, icolor.g, icolor.b, 1.0f};
             }
             if (outerClipColorRes) {
-                routeOptions.outerClipColor = *outerClipColorRes;
+                mbgl::Color oclipcolor = *outerClipColorRes;
+                routeOptions.outerClipColor = {oclipcolor.r, oclipcolor.g, oclipcolor.b, 1.0f};
             }
             if (innerClipColorRes) {
-                routeOptions.innerClipColor = *innerClipColorRes;
+                mbgl::Color iclipcolor = *innerClipColorRes;
+                routeOptions.innerClipColor = {iclipcolor.r, iclipcolor.g, iclipcolor.b, 1.0f};
             }
             routeOptions.outerWidth = outerWidth;
             routeOptions.innerWidth = innerWidth;
@@ -1732,13 +1736,14 @@ jboolean NativeMapView::routeSegmentCreate(JNIEnv& env,
         Converter<mbgl::Color, int> colorConverter;
         Result<Color> innerSegmentColorRes = colorConverter(env, color);
         if (innerSegmentColorRes) {
-            rsegopts.color = *innerSegmentColorRes;
-            rsegopts.color.a = 1.0f;
+            mbgl::Color isegcolor = *innerSegmentColorRes;
+            rsegopts.color = {isegcolor.r, isegcolor.g, isegcolor.b, 1.0f};
         }
 
         Result<Color> outerSegmentColorRes = colorConverter(env, outerColor);
         if (outerSegmentColorRes) {
-            rsegopts.outerColor = *outerSegmentColorRes;
+            mbgl::Color osegcolor = *outerSegmentColorRes;
+            rsegopts.outerColor = {osegcolor.r, osegcolor.g, osegcolor.b, 1.0f};
         }
 
         return routeMgr->routeSegmentCreate(RouteID(routeID), rsegopts);

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -1651,6 +1651,7 @@ jint NativeMapView::routeCreate(JNIEnv& env,
             Result<Color> innerColorRes = colorConverter(env, innerColor);
             Result<Color> outerClipColorRes = colorConverter(env, outerClipColor);
             Result<Color> innerClipColorRes = colorConverter(env, innerClipColor);
+            // set alpha to 1 for all colors except for clip colors
             if (outerColorRes) {
                 mbgl::Color ocolor = *outerColorRes;
                 routeOptions.outerColor = {ocolor.r, ocolor.g, ocolor.b, 1.0f};
@@ -1661,11 +1662,9 @@ jint NativeMapView::routeCreate(JNIEnv& env,
             }
             if (outerClipColorRes) {
                 mbgl::Color oclipcolor = *outerClipColorRes;
-                routeOptions.outerClipColor = {oclipcolor.r, oclipcolor.g, oclipcolor.b, 1.0f};
             }
             if (innerClipColorRes) {
                 mbgl::Color iclipcolor = *innerClipColorRes;
-                routeOptions.innerClipColor = {iclipcolor.r, iclipcolor.g, iclipcolor.b, 1.0f};
             }
             routeOptions.outerWidth = outerWidth;
             routeOptions.innerWidth = innerWidth;

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -1589,6 +1589,8 @@ void NativeMapView::registerNative(jni::JNIEnv& env) {
         METHOD(&NativeMapView::routeSegmentsClear, "nativeRouteClearSegments"),
         METHOD(&NativeMapView::routeSegmentCreate, "nativeRouteSegmentCreate"),
         METHOD(&NativeMapView::getRenderingStats, "nativeGetRenderingStats"),
+        METHOD(&NativeMapView::routeSetVanishing, "nativeRouteSetVanishing"),
+        METHOD(&NativeMapView::routeGetVanishing, "nativeRouteGetVanishing"),
         METHOD(&NativeMapView::routeQueryRendered, "nativeRouteQuery"),
         METHOD(&NativeMapView::routesGetCaptureSnapshot, "nativeRoutesCaptureSnapshot"),
         METHOD(&NativeMapView::routesFinalize, "nativeRoutesFinalize"),
@@ -1769,6 +1771,22 @@ void NativeMapView::routeSegmentsClear(JNIEnv& env, jint routeID) {
     if (routeMgr) {
         routeMgr->routeClearSegments(RouteID(routeID));
     }
+}
+
+jboolean NativeMapView::routeSetVanishing(JNIEnv& env, jni::jint routeID) {
+    if (routeMgr) {
+        return routeMgr->setVanishingRouteID(RouteID(routeID));
+    }
+
+    return false;
+}
+
+jint NativeMapView::routeGetVanishing(JNIEnv& env) {
+    if (routeMgr) {
+        return routeMgr->getVanishingRouteID().id;
+    }
+
+    return -1;
 }
 
 jboolean NativeMapView::routesFinalize(JNIEnv& env) {

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -1653,18 +1653,18 @@ jint NativeMapView::routeCreate(JNIEnv& env,
             Result<Color> innerClipColorRes = colorConverter(env, innerClipColor);
             // set alpha to 1 for all colors except for clip colors
             if (outerColorRes) {
-                mbgl::Color ocolor = *outerColorRes;
+                const mbgl::Color& ocolor = *outerColorRes;
                 routeOptions.outerColor = {ocolor.r, ocolor.g, ocolor.b, 1.0f};
             }
             if (innerColorRes) {
-                mbgl::Color icolor = *innerColorRes;
+                const mbgl::Color& icolor = *innerColorRes;
                 routeOptions.innerColor = {icolor.r, icolor.g, icolor.b, 1.0f};
             }
             if (outerClipColorRes) {
-                mbgl::Color oclipcolor = *outerClipColorRes;
+                routeOptions.outerClipColor = *outerClipColorRes;
             }
             if (innerClipColorRes) {
-                mbgl::Color iclipcolor = *innerClipColorRes;
+                routeOptions.innerClipColor = *innerClipColorRes;
             }
             routeOptions.outerWidth = outerWidth;
             routeOptions.innerWidth = innerWidth;

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
@@ -277,6 +277,10 @@ public:
     jint routeQueryRendered(JNIEnv& env, jni::jdouble screenSpaceX, jni::jdouble screenSpaceY, jni::jint radius);
 
     jboolean routesFinalize(JNIEnv& env);
+
+    jboolean routeSetVanishing(JNIEnv& env, jni::jint routeID);
+
+    jint routeGetVanishing(JNIEnv& env);
     //------------------------------------------------
 
     jni::Local<jni::String> getRenderingStats(JNIEnv& env, jni::jboolean oneline);

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapView.java
@@ -64,7 +64,6 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   private final MapChangeReceiver mapChangeReceiver = new MapChangeReceiver();
   private final MapCallback mapCallback = new MapCallback();
   private final InitialRenderCallback initialRenderCallback = new InitialRenderCallback();
-  private RouteID vanishingRouteID = new RouteID(-1);
   private boolean isPointBasedRouteQueryCoarse = true;
   private boolean isAutoRouteVanishing = true;
   private double latestRouteProgressPercent = 0.0;
@@ -535,7 +534,11 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
    * @param routeID the specified route ID for the corresponding route to vanish.
    */
   public void setVanishingRoute(RouteID routeID) {
-    vanishingRouteID = routeID;
+    nativeMapView.setVanishingRoute(routeID);
+  }
+
+  public RouteID getVanishingRouteID() {
+    return nativeMapView.getVanishingRoute();
   }
 
   /**
@@ -675,6 +678,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
                                  float iconScale,
                                  boolean cameraTracking) {
     mapRenderer.nativeSetCustomPuckState(lat, lon, bearing, iconScale, cameraTracking);
+    RouteID vanishingRouteID = getVanishingRouteID();
     if(isAutoRouteVanishing && vanishingRouteID.isValid()) {
       double percent = nativeMapView.setRouteProgressPoint(vanishingRouteID, Point.fromLngLat(lon, lat), isPointBasedRouteQueryCoarse, false);
       if(percent >= 0.0 && percent <= 1.0) {

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMap.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMap.java
@@ -290,6 +290,10 @@ interface NativeMap {
 
   void clearRouteSegments(RouteID routeID);
 
+  boolean setVanishingRoute(RouteID routeID);
+
+  RouteID getVanishingRoute();
+
   boolean finalizeRoutes();
 
   String getRenderingStats(boolean oneline);

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
@@ -47,6 +47,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.TreeMap;
 
+import okhttp3.Route;
+
 // Class that wraps the native methods for convenience
 final class NativeMapView implements NativeMap {
 
@@ -1232,6 +1234,22 @@ final class NativeMapView implements NativeMap {
     }
   }
 
+
+  @Override
+  public boolean setVanishingRoute(RouteID routeID) {
+    if(routeID.isValid()) {
+      return nativeRouteSetVanishing(routeID.getId());
+    }
+
+    return false;
+  }
+
+  @Override
+  public RouteID getVanishingRoute() {
+    int routeIDint = nativeRouteGetVanishing();
+    return new RouteID(routeIDint);
+  }
+
   @Override
   public boolean finalizeRoutes() {
     return nativeRoutesFinalize();
@@ -1693,6 +1711,12 @@ final class NativeMapView implements NativeMap {
 
   @Keep
   private native String nativeRoutesCaptureSnapshot();
+
+  @Keep
+  private native boolean nativeRouteSetVanishing(int routeID);
+
+  @Keep
+  private native int nativeRouteGetVanishing();
 
   @Keep
   native void nativeRoutesClearStats();

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
@@ -47,7 +47,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.TreeMap;
 
-import okhttp3.Route;
 
 // Class that wraps the native methods for convenience
 final class NativeMapView implements NativeMap {

--- a/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/routes/RouteUtils.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/routes/RouteUtils.kt
@@ -146,17 +146,13 @@ class RouteUtils {
             Timber.tag("RouteProgress").i("getPoint: $point")
             val calculatedPercent = mapView.setRouteProgressPoint(routeID, point, progressPrecisionCoarse, false)
             Timber.tag("RouteProgress").i("inputPercent: $progress , calculatedPercent: $calculatedPercent")
-
-//            mapView.setCustomPuckState(point.latitude(), point.longitude(), 0.0, 1.0f, false)
-
         }
 
-        fun setPercentProgress(mapView: MapView, percent: Double) {
+        fun getPointProgress(progress: Double) : Point {
             val routeID = routeMap.keys.first()
             val routeCircle = routeMap[routeID]
-            if(routeCircle == null) return
 
-            mapView.setRouteProgressPercent(routeID, percent)
+            return routeCircle?.getPoint(progress)!!
         }
 
         fun addRoute(mapView : MapView) {
@@ -176,6 +172,10 @@ class RouteUtils {
 
             val routeID = mapView.createRoute(routeGeometry, routeOptions)
             mapView.finalizeRoutes()
+            //set the first routeID as the vanishing route
+            if  (routeMap.isEmpty()) {
+                mapView.setVanishingRoute(routeID)
+            }
             routeMap[routeID] = routeCircle
 
             addTrafficSegments(routeID, mapView)

--- a/platform/android/MapLibreAndroidTestApp/src/main/res/layout/activity_routes.xml
+++ b/platform/android/MapLibreAndroidTestApp/src/main/res/layout/activity_routes.xml
@@ -37,27 +37,6 @@
                 tools:ignore="HardcodedText"/>
 
         <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
-            <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:id="@+id/route_progress_text"
-                    android:text="Progress Mode "
-                    android:textColor="#000000"
-                    tools:ignore="HardcodedText"/>
-
-            <Spinner
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:id="@+id/route_progress_mode"
-                    android:background="@color/primary"
-            />
-
-        </LinearLayout>
-
-        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="horizontal">

--- a/platform/glfw/glfw_backend.hpp
+++ b/platform/glfw/glfw_backend.hpp
@@ -17,6 +17,10 @@ public:
     GLFWBackend(const GLFWBackend&) = delete;
     GLFWBackend& operator=(const GLFWBackend&) = delete;
     virtual ~GLFWBackend() = default;
+    virtual void setCustomPuckState([[maybe_unused]] double lat,
+                                    [[maybe_unused]] double lon,
+                                    [[maybe_unused]] double bearing) {};
+    virtual void enableCustomPuck([[maybe_unused]] bool onOff) {};
 
     static std::unique_ptr<GLFWBackend> Create(GLFWwindow* window, bool capFrameRate) {
         return mbgl::gfx::Backend::Create<GLFWBackend, GLFWwindow*, bool>(window, capFrameRate);

--- a/platform/glfw/glfw_gl_backend.cpp
+++ b/platform/glfw/glfw_gl_backend.cpp
@@ -1,5 +1,7 @@
 #include "glfw_gl_backend.hpp"
 
+#include "mbgl/util/io.hpp"
+
 #include <mbgl/gfx/backend_scope.hpp>
 #include <mbgl/gl/renderable_resource.hpp>
 #include <mbgl/util/instrumentation.hpp>
@@ -51,6 +53,25 @@ GLFWGLBackend::GLFWGLBackend(GLFWwindow* window_, const bool capFrameRate)
 }
 
 GLFWGLBackend::~GLFWGLBackend() = default;
+
+mbgl::gfx::CustomPuckState GLFWGLBackend::getCurrentCustomPuckState() const {
+    return customPuckState_;
+}
+
+void GLFWGLBackend::setCustomPuckState(double lat, double lon, double bearing) {
+    customPuckState_.lat = lat;
+    customPuckState_.lon = lon;
+    customPuckState_.bearing = bearing;
+};
+
+void GLFWGLBackend::enableCustomPuck(bool onOff) {
+    customPuckState_.enabled = onOff;
+    customPuckState_.cameraTracking = false;
+    customPuckState_.bearing = 0;
+    if (onOff) {
+        customPuck->setPuckBitmap(mbgl::decodeImage(mbgl::util::read_file("../../../platform/glfw/assets/puck.png")));
+    }
+};
 
 void GLFWGLBackend::activate() {
     MLN_TRACE_FUNC();

--- a/platform/glfw/glfw_gl_backend.hpp
+++ b/platform/glfw/glfw_gl_backend.hpp
@@ -17,6 +17,9 @@ public:
     // GLFWRendererBackend implementation
 public:
     mbgl::gfx::RendererBackend& getRendererBackend() override { return *this; }
+    virtual mbgl::gfx::CustomPuckState getCurrentCustomPuckState() const override;
+    virtual void setCustomPuckState(double lat, double lon, double bearing) override;
+    virtual void enableCustomPuck(bool onOff) override;
     mbgl::Size getSize() const override;
     void setSize(mbgl::Size) override;
 
@@ -27,6 +30,8 @@ public:
 protected:
     void activate() override;
     void deactivate() override;
+
+    mbgl::gfx::CustomPuckState customPuckState_;
 
     // mbgl::gl::RendererBackend implementation
 protected:

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -1223,6 +1223,9 @@ void GLFWView::addTrafficSegments() {
             rsegopts.outerColor = mbgl::Color(float(i) / float(trafficBlks.size() - 1), 0.0, 0.0, 1.0);
             const bool success = rmptr_->routeSegmentCreate(routeID, rsegopts);
             assert(success && "failed to create route segment");
+            if (!success) {
+                std::cerr << "failed to create route segment" << std::endl;
+            }
         }
         trafficBlks.clear();
     }
@@ -1551,6 +1554,9 @@ void GLFWView::readAndLoadCapture(const std::string &capture_file_name) {
 
                 bool success = rmptr_->routeSet(routeID, route_geom, routeOpts);
                 assert(success && "failed to create route on pre-created route ID");
+                if (!success) {
+                    std::cerr << "failed to create route on pre-created route ID" << std::endl;
+                }
                 RouteCircle routeCircle;
                 routeCircle.points = route_geom;
                 routeCircle.resolution = route_geom.size();

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -741,10 +741,6 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
                     view->decrementRouteProgress();
                     break;
 
-                case GLFW_KEY_P:
-                    view->setRouteProgressUsage();
-                    break;
-
                 case GLFW_KEY_S: {
                     view->captureSnapshot();
                     std::cout << "captured snapshot" << std::endl;
@@ -1067,11 +1063,31 @@ void GLFWView::addRoute() {
     routeOpts.innerClipColor = mbgl::Color(0.5, 0.5, 0.5, 1.0);
 
     auto routeID = rmptr_->routeCreate(geom, routeOpts);
-    if (!firstRouteID_.isValid()) {
-        firstRouteID_ = routeID;
-    }
     routeMap_[routeID] = route;
     rmptr_->finalize();
+
+    if (!vanishingRouteID_.isValid()) {
+        vanishingRouteID_ = routeID;
+        rmptr_->setVanishingRouteID(vanishingRouteID_);
+        enablePuck(true);
+
+        const mbgl::Point<double> &pt = routeMap_[vanishingRouteID_].getPoint(0.0);
+        setPuckLocation(pt.y, pt.x, 90.0);
+    }
+}
+
+void GLFWView::enablePuck(bool onOff) {
+    backend->enableCustomPuck(onOff);
+}
+
+void GLFWView::setPuckLocation(double lat, double lon, double bearing) {
+    backend->setCustomPuckState(lat, lon, bearing);
+    mbgl::Point<double> progressPt = {lon, lat};
+    if (vanishingRouteID_.isValid()) {
+        double percent = rmptr_->routeSetProgressPoint(
+            vanishingRouteID_, progressPt, routeProgressPrecision_, captureNavPoints_);
+        std::cout << "set puck location - percent: " << std::to_string(percent) << std::endl;
+    }
 }
 
 std::vector<GLFWView::TrafficBlock> GLFWView::testCases(const RouteSegmentTestCases &testcase,
@@ -1281,15 +1297,6 @@ void GLFWView::modifyTrafficViz() {
     }
 }
 
-void GLFWView::setRouteProgressUsage() {
-    generateRouteProgressPercent_ = !generateRouteProgressPercent_;
-    if (generateRouteProgressPercent_) {
-        std::cout << "Using route progress percent" << std::endl;
-    } else {
-        std::cout << "Using route progress point" << std::endl;
-    }
-}
-
 void GLFWView::setRoutePickMode() {
     routePickMode_ = !routePickMode_;
     std::string routePickModeStr = routePickMode_ ? "routePickMode ON" : "routePickMode OFF";
@@ -1305,47 +1312,44 @@ GLFWRendererFrontend *GLFWView::getRenderFrontend() const {
 }
 
 void GLFWView::incrementRouteProgress() {
-    if (firstRouteID_.isValid() && routeMap_.find(firstRouteID_) != routeMap_.end()) {
+    if (vanishingRouteID_.isValid() && routeMap_.find(vanishingRouteID_) != routeMap_.end()) {
         routeProgress_ += ROUTE_PROGRESS_STEP;
         routeProgress_ = std::clamp<double>(routeProgress_, 0.0, 1.0f);
-        if (generateRouteProgressPercent_) {
-            rmptr_->routeSetProgressPercent(firstRouteID_, routeProgress_);
-        } else {
-            const mbgl::Point<double> &progressPoint = rmptr_->getPoint(
-                firstRouteID_, routeProgress_, mbgl::route::Precision::Fine);
-            // TODO: test out which algorithm works in nav app before removing dead code
-            //  double percent = rmptr_->routeSetProgress(routeID, progressPoint, captureNavPoints);
-            //  std::cout<<", calculated percent: "<<percent<<std::endl;
 
-            rmptr_->routeSetProgressPoint(
-                firstRouteID_, progressPoint, mbgl::route::Precision::Fine, captureNavPoints_);
+        double bearing = 0.0;
+        const mbgl::Point<double> &progressPoint = rmptr_->getPoint(
+            vanishingRouteID_, routeProgress_, routeProgressPrecision_, &bearing);
+
+        if (!enableAutoVanishing) {
+            rmptr_->routeSetProgressPoint(vanishingRouteID_, progressPoint, routeProgressPrecision_, captureNavPoints_);
             // std::cout << "Route progress: " << std::to_string(routeProgress_) << ", calculated percent: " <<
             // std::to_string(percentage) << std::endl;
+            rmptr_->finalize();
         }
-        rmptr_->finalize();
+        setPuckLocation(progressPoint.y, progressPoint.x, bearing);
+    }
+    if (enableAutoVanishing) {
+        invalidate();
     }
 }
 
 void GLFWView::decrementRouteProgress() {
-    if (firstRouteID_.isValid() && routeMap_.find(firstRouteID_) != routeMap_.end()) {
+    if (vanishingRouteID_.isValid() && routeMap_.find(vanishingRouteID_) != routeMap_.end()) {
         routeProgress_ -= ROUTE_PROGRESS_STEP;
         routeProgress_ = std::clamp<double>(routeProgress_, 0.0, 1.0f);
 
-        if (generateRouteProgressPercent_) {
-            rmptr_->routeSetProgressPercent(firstRouteID_, routeProgress_, captureNavPoints_);
-        } else {
-            mbgl::Point<double> progressPoint = routeMap_[firstRouteID_].getPoint(routeProgress_);
-            // TODO: test out which algorithm works in nav app before removing dead code
-            //  double percent = rmptr_->routeSetProgress(routeID, progressPoint, captureNavPoints);
-            //  std::cout<<", calculated percent: "<<percent<<std::endl;
+        double bearing = 0.0;
+        mbgl::Point<double> progressPoint = rmptr_->getPoint(
+            vanishingRouteID_, routeProgress_, routeProgressPrecision_, &bearing);
 
-            rmptr_->routeSetProgressPoint(
-                firstRouteID_, progressPoint, mbgl::route::Precision::Coarse, captureNavPoints_);
-            // std::cout << "Route progress: " << std::to_string(routeProgress_) << ", calculated percent: " <<
-            // std::to_string(percentage) << std::endl;
+        if (!enableAutoVanishing) {
+            rmptr_->routeSetProgressPoint(vanishingRouteID_, progressPoint, routeProgressPrecision_, captureNavPoints_);
+            rmptr_->finalize();
         }
-
-        rmptr_->finalize();
+        setPuckLocation(progressPoint.y, progressPoint.x, bearing);
+    }
+    if (enableAutoVanishing) {
+        invalidate();
     }
 }
 
@@ -1361,8 +1365,8 @@ void GLFWView::disposeRoute() {
         auto &routeID = routeMap_.begin()->first;
         bool success = rmptr_->routeDispose(routeID);
         if (success) {
-            if (firstRouteID_ == routeID) {
-                firstRouteID_ = RouteID();
+            if (vanishingRouteID_ == routeID) {
+                vanishingRouteID_ = RouteID();
             }
             routeMap_.erase(routeID);
         }
@@ -1400,7 +1404,7 @@ void GLFWView::readAndLoadCapture(const std::string &capture_file_name) {
     for (size_t i = 0; i < routeMap_.size(); i++) {
         disposeRoute();
     }
-    firstRouteID_ = RouteID();
+    vanishingRouteID_ = RouteID();
     rmptr_->setStyle(map->getStyle());
 
     std::ifstream jsonfile(capture_file_name);
@@ -1564,7 +1568,12 @@ void GLFWView::readAndLoadCapture(const std::string &capture_file_name) {
                             capturedNavStopMap_[routeID].push_back({x, y});
                         }
                     }
-                    if (!firstRouteID_.isValid()) firstRouteID_ = routeID;
+                    if (!vanishingRouteID_.isValid()) {
+                        vanishingRouteID_ = routeID;
+                        enablePuck(true);
+                        const mbgl::Point<double> &pt = routeMap_[vanishingRouteID_].getPoint(0.0);
+                        setPuckLocation(pt.y, pt.x, 90.0);
+                    }
                 }
 
                 if (route_obj.HasMember("nav_stops_percent") && route_obj["nav_stops_percent"].IsArray()) {
@@ -1579,7 +1588,15 @@ void GLFWView::readAndLoadCapture(const std::string &capture_file_name) {
                 }
 
                 rmptr_->finalize();
-
+                // if there is no vanishing route defined in the capture, it means we have not captured nav stops.
+                // lets just set the first route in the map as the vanishing route.
+                if (!vanishingRouteID_.isValid()) {
+                    vanishingRouteID_ = routeMap_.begin()->first;
+                    rmptr_->setVanishingRouteID(vanishingRouteID_);
+                    enablePuck(true);
+                    const mbgl::Point<double> &pt = routeMap_[vanishingRouteID_].getPoint(0.0);
+                    setPuckLocation(pt.y, pt.x, 90.0);
+                }
                 // create route segments
                 if (route_obj.HasMember("route_segments") && route_obj["route_segments"].IsArray()) {
                     const rapidjson::Value &route_segments = route_obj["route_segments"];
@@ -1627,27 +1644,24 @@ void GLFWView::readAndLoadCapture(const std::string &capture_file_name) {
 }
 
 void GLFWView::scrubNavStops(bool forward) {
-    if (loadedCapture_ && firstRouteID_.isValid()) {
+    if (loadedCapture_ && vanishingRouteID_.isValid() &&
+        capturedNavStopMap_.find(vanishingRouteID_) != capturedNavStopMap_.end()) {
         if (forward) {
             ++lastNavStop_;
         } else {
             --lastNavStop_;
         }
-        if (capturedNavStopMap_.find(firstRouteID_) != capturedNavStopMap_.end()) {
-            const mbgl::LineString<double> &navstops = capturedNavStopMap_[firstRouteID_];
-            const uint32_t sz = navstops.size();
-            const auto &navStop = navstops[lastNavStop_ % sz];
-            double percentage = rmptr_->routeSetProgressPoint(firstRouteID_, navStop, routePrecision_);
+
+        const mbgl::LineString<double> &navstops = capturedNavStopMap_[vanishingRouteID_];
+        const uint32_t sz = navstops.size();
+        const auto &navStop = navstops[lastNavStop_ % sz];
+        if (!enableAutoVanishing) {
+            double percentage = rmptr_->routeSetProgressPoint(vanishingRouteID_, navStop, routePrecision_);
             rmptr_->finalize();
             std::cout << "percent: " << std::to_string(percentage) << std::endl;
-        } else if (capturedNavPercentMap_.find(firstRouteID_) != capturedNavPercentMap_.end()) {
-            const auto &navstops = capturedNavPercentMap_[firstRouteID_];
-            const uint32_t sz = navstops.size();
-            const double percent = navstops[lastNavStop_ % sz];
-            rmptr_->routeSetProgressPercent(firstRouteID_, percent);
-            rmptr_->finalize();
         }
-    } else if (loadedCapture_) {
+        setPuckLocation(navStop.y, navStop.x, 90.0);
+    } else if (loadedCapture_ && vanishingRouteID_.isValid()) {
         // perhaps the capture file did not have nav stops, lets just pick the first route we see and traverse it.
         if (!routeMap_.empty()) {
             if (forward) {
@@ -1657,13 +1671,19 @@ void GLFWView::scrubNavStops(bool forward) {
             }
             const auto &routeID = routeMap_.begin()->first;
             routeProgress_ = std::clamp<double>(routeProgress_, 0.0, 1.0f);
-            const auto &navstop = rmptr_->getPoint(routeID, routeProgress_, routePrecision_);
-            double percentage = rmptr_->routeSetProgressPoint(routeID, navstop, routePrecision_);
-            std::cout << ", ip %: " << std::to_string(routeProgress_)
-                      << ", calculated %: " << std::to_string(percentage) << std::endl;
-
-            rmptr_->finalize();
+            double bearing = 0.0;
+            const auto &navstop = rmptr_->getPoint(routeID, routeProgress_, routePrecision_, &bearing);
+            if (!enableAutoVanishing) {
+                double percentage = rmptr_->routeSetProgressPoint(routeID, navstop, routePrecision_);
+                std::cout << ", ip %: " << std::to_string(routeProgress_)
+                          << ", calculated %: " << std::to_string(percentage) << std::endl;
+                rmptr_->finalize();
+            }
+            setPuckLocation(navstop.y, navstop.x, bearing);
         }
+    }
+    if (enableAutoVanishing) {
+        invalidate();
     }
 }
 

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -1571,8 +1571,10 @@ void GLFWView::readAndLoadCapture(const std::string &capture_file_name) {
                     if (!vanishingRouteID_.isValid()) {
                         vanishingRouteID_ = routeID;
                         enablePuck(true);
-                        const mbgl::Point<double> &pt = routeMap_[vanishingRouteID_].getPoint(0.0);
-                        setPuckLocation(pt.y, pt.x, 90.0);
+                        double bearing = 0.0;
+                        const mbgl::Point<double> &pt = rmptr_->getPoint(
+                            vanishingRouteID_, 0.0, routePrecision_, &bearing);
+                        setPuckLocation(pt.y, pt.x, bearing);
                     }
                 }
 
@@ -1594,8 +1596,9 @@ void GLFWView::readAndLoadCapture(const std::string &capture_file_name) {
                     vanishingRouteID_ = routeMap_.begin()->first;
                     rmptr_->setVanishingRouteID(vanishingRouteID_);
                     enablePuck(true);
-                    const mbgl::Point<double> &pt = routeMap_[vanishingRouteID_].getPoint(0.0);
-                    setPuckLocation(pt.y, pt.x, 90.0);
+                    double bearing = 0.0;
+                    const mbgl::Point<double> &pt = rmptr_->getPoint(vanishingRouteID_, 0.0, routePrecision_, &bearing);
+                    setPuckLocation(pt.y, pt.x, bearing);
                 }
                 // create route segments
                 if (route_obj.HasMember("route_segments") && route_obj["route_segments"].IsArray()) {

--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -122,10 +122,11 @@ private:
     void addTrafficSegments();
     void modifyTrafficViz();
     void removeTrafficViz();
+    void enablePuck(bool onOff);
+    void setPuckLocation(double lat, double lon, double bearing);
     void incrementRouteProgress();
     void decrementRouteProgress();
     void captureSnapshot();
-    void setRouteProgressUsage();
     void setRoutePickMode();
     void scrubNavStops(bool forward);
 
@@ -199,14 +200,15 @@ private:
     std::unordered_map<RouteID, RouteCircle, IDHasher<RouteID>> routeMap_;
     std::unordered_map<RouteID, mbgl::LineString<double>, IDHasher<RouteID>> capturedNavStopMap_;
     std::unordered_map<RouteID, std::vector<double>, IDHasher<RouteID>> capturedNavPercentMap_;
+    mbgl::route::Precision routeProgressPrecision_ = mbgl::route::Precision::Fine;
     int lastCaptureIdx_ = 0;
     uint32_t lastNavStop_ = 0;
-    RouteID firstRouteID_;
+    RouteID vanishingRouteID_;
     bool loadedCapture_ = false;
     double routeProgress_ = 0.0;
-    bool generateRouteProgressPercent_ = false;
     bool routePickMode_ = false;
     bool captureNavPoints_ = true;
+    bool enableAutoVanishing = false; // Simulates route progress in app
     mbgl::route::Precision routePrecision_ = mbgl::route::Precision::Fine;
 
     // Frame timer

--- a/src/mbgl/route/route.cpp
+++ b/src/mbgl/route/route.cpp
@@ -162,7 +162,44 @@ Route::Route(const LineString<double>& geometry, const RouteOptions& ropts)
     }
 }
 
-Point<double> Route::getPointCoarse(double percentage) const {
+std::optional<double> Route::getVectorOrientation(double x, double y) {
+    // Handle the zero vector case (angle is undefined)
+    if (x == 0.0 && y == 0.0) {
+        return std::nullopt;
+    }
+
+    // Calculate the angle in radians using std::atan2(x, y).
+    // std::atan2(x, y) returns an angle where:
+    // - Positive Y-axis (North, vector (0,y_pos)) is 0 radians.
+    // - Positive X-axis (East, vector (x_pos,0)) is PI/2 radians.
+    // - Negative Y-axis (South, vector (0,y_neg)) is PI radians.
+    // - Negative X-axis (West, vector (x_neg,0)) is -PI/2 radians.
+    // This convention means positive angles are measured clockwise from North.
+    double angleRadians = std::atan2(x, y);
+
+    // Convert radians to degrees
+    double angleDegrees = angleRadians * (180.0 / M_PI);
+    // Normalize the angle to be in the range [0, 360) degrees.
+    // std::atan2 returns values in (-PI, PI], so angleDegrees is in (-180, 180].
+    if (angleDegrees < 0.0) {
+        angleDegrees += 360.0;
+    }
+
+    // Ensure that if the angle is exactly 360 (e.g. due to -0.0 input that got normalized),
+    // it is represented as 0.0. This also handles the case where angleDegrees might be -0.0
+    // which is fine, but for strict [0,360) output where 360 becomes 0.
+    if (angleDegrees == 360.0) {
+        return 0.0;
+    }
+    // Handle -0.0 becoming 0.0 for consistent output if desired, though numerically they are same.
+    if (angleDegrees == -0.0) {
+        return 0.0;
+    }
+
+    return angleDegrees;
+}
+
+Point<double> Route::getPointCoarse(double percentage, double* bearing) const {
     if (geometry_.empty()) {
         throw std::invalid_argument("Route cannot be empty.");
     }
@@ -201,6 +238,11 @@ Point<double> Route::getPointCoarse(double percentage) const {
             const Point<double>& p1 = geometry_[i];
             const Point<double>& p2 = geometry_[i + 1];
 
+            if (bearing != nullptr) {
+                std::optional<double> bearingOpt = getVectorOrientation(p2.x - p1.x, p2.y - p1.y);
+                *bearing = bearingOpt.has_value() ? bearingOpt.value() : 0.0;
+            }
+
             // Calculate how far into the current segment the target distance is
             double lenNeededInInterval = target_distance - currCumulativeLen;
 
@@ -238,7 +280,7 @@ Point<double> Route::getPointCoarse(double percentage) const {
     return geometry_.back();
 }
 
-Point<double> Route::getPointFine(double percentage) const {
+Point<double> Route::getPointFine(double percentage, double* bearing) const {
     if (geometry_.empty()) {
         throw std::invalid_argument("Route cannot be empty.");
     }
@@ -276,6 +318,11 @@ Point<double> Route::getPointFine(double percentage) const {
         if (cumulativeLen + currIntervalLen >= targetLen - EPSILON) {
             const Point<double>& p1 = geometry_[i];
             const Point<double>& p2 = geometry_[i + 1];
+
+            if (bearing != nullptr) {
+                std::optional<double> bearingOpt = getVectorOrientation(p2.x - p1.x, p2.y - p1.y);
+                *bearing = bearingOpt.has_value() ? bearingOpt.value() : 0.0;
+            }
 
             double distance_needed_in_segment = targetLen - cumulativeLen;
             double intervalFraction = 0.0;
@@ -335,12 +382,12 @@ Point<double> Route::getPointFine(double percentage) const {
     return geometry_.back();
 }
 
-mbgl::Point<double> Route::getPoint(double percentage, const Precision& precision) const {
+mbgl::Point<double> Route::getPoint(double percentage, const Precision& precision, double* bearing) const {
     switch (precision) {
         case Precision::Coarse:
-            return getPointCoarse(percentage);
+            return getPointCoarse(percentage, bearing);
         case Precision::Fine:
-            return getPointFine(percentage);
+            return getPointFine(percentage, bearing);
         default:
             throw std::invalid_argument("Invalid precision type.");
     }

--- a/src/mbgl/route/route_manager.cpp
+++ b/src/mbgl/route/route_manager.cpp
@@ -557,10 +557,13 @@ double RouteManager::routeSetProgressPoint(const RouteID& routeID,
     return percentage;
 }
 
-mbgl::Point<double> RouteManager::getPoint(const RouteID& routeID, double percent, const Precision& precision) const {
+mbgl::Point<double> RouteManager::getPoint(const RouteID& routeID,
+                                           double percent,
+                                           const Precision& precision,
+                                           double* bearing) const {
     assert(routeID.isValid() && "invalid route ID");
     if (routeID.isValid() && routeMap_.find(routeID) != routeMap_.end()) {
-        return routeMap_.at(routeID).getPoint(percent, precision);
+        return routeMap_.at(routeID).getPoint(percent, precision, bearing);
     }
 
     return {0.0, 0.0};
@@ -818,6 +821,20 @@ void RouteManager::finalizeRoute(const RouteID& routeID, const DirtyType& dt) {
             casingRouteLineLayer->setGradientLineClip(progress);
         }
     }
+}
+
+bool RouteManager::setVanishingRouteID(const RouteID& routeID) {
+    bool success = false;
+    if (routeID.isValid() && routeMap_.find(routeID) != routeMap_.end() && style_ != nullptr) {
+        vanishingRouteID_ = routeID;
+        success = true;
+    }
+
+    return success;
+}
+
+RouteID RouteManager::getVanishingRouteID() const {
+    return vanishingRouteID_;
 }
 
 void RouteManager::finalize() {


### PR DESCRIPTION
This PR has the following supports:

1. Fix for the purple route segment, kotlin sends us RGB but our jni color converter expects ARGB. Fix is to set alpha to 1.
2. Added support for puck rendering in GLFW and android
3. Currently the vanishing route ID was in MapView.java, it is now pushed into RouteManager for better maintainance
4. Removed the expensive formatting string stream used to format logs.
5. Added metrics to measure vanishing route for long distances

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alproton/maplibre-native/35)
<!-- Reviewable:end -->
