### PR TITLE
support for fine precision route segments

### DIFF
--- a/include/mbgl/route/route_segment.hpp
+++ b/include/mbgl/route/route_segment.hpp
@@ -18,10 +18,7 @@ struct RouteSegmentOptions {
 class RouteSegment {
 public:
     RouteSegment() = delete;
-    RouteSegment(const RouteSegmentOptions& routeSegOptions,
-                 const LineString<double>& routeGeometry,
-                 const std::vector<double>& routeGeomDistances,
-                 double routeTotalDistance);
+    RouteSegment(const RouteSegmentOptions& routeSegOptions, const std::vector<double>& normalizedPositions);
     std::vector<double> getNormalizedPositions() const;
     RouteSegmentOptions getRouteSegmentOptions() const;
 

--- a/src/mbgl/route/route_segment.cpp
+++ b/src/mbgl/route/route_segment.cpp
@@ -7,77 +7,9 @@
 namespace mbgl {
 namespace route {
 
-namespace {
-// Function to check if point A is between points B and C
-bool isPointBetween(const mbgl::Point<double>& A,
-                    const mbgl::Point<double>& B,
-                    const mbgl::Point<double>& C,
-                    bool quickDirty = false) {
-    // Check if the points are collinear (on the same line)
-    double crossProduct = (C.y - B.y) * (A.x - B.x) - (C.x - B.x) * (A.y - B.y);
-
-    if (std::abs(crossProduct) > 1e-9) { // Using a small epsilon for floating-point comparison
-        return false;                    // Not collinear, so A cannot be between B and C
-    }
-
-    // Check if A is within the bounding box of B and C.  This is a simplified version.
-    // A more robust check would involve projecting A onto the line BC and checking
-    // if the projection lies within the segment BC.  The bounding box check is sufficient
-    // for many common cases and is less computationally expensive.
-    if (quickDirty) {
-        double minX = std::min(B.x, C.x);
-        double maxX = std::max(B.x, C.x);
-        double minY = std::min(B.y, C.y);
-        double maxY = std::max(B.y, C.y);
-
-        return (A.x >= minX && A.x <= maxX && A.y >= minY && A.y <= maxY);
-    }
-
-    // More robust check (projection method - commented out for brevity, but recommended):
-    double dotProduct = (A.x - B.x) * (C.x - B.x) + (A.y - B.y) * (C.y - B.y);
-    double squaredLengthBC = (C.x - B.x) * (C.x - B.x) + (C.y - B.y) * (C.y - B.y);
-
-    if (squaredLengthBC == 0) {            // B and C are the same point
-        return (A.x == B.x && A.y == B.y); // A must be equal to B (and C)
-    }
-
-    double t = dotProduct / squaredLengthBC;
-
-    return (t >= 0 && t <= 1);
-}
-} // namespace
-
-RouteSegment::RouteSegment(const RouteSegmentOptions& routeSegOptions,
-                           const LineString<double>& routeGeometry,
-                           const std::vector<double>& routeGeomDistances,
-                           double routeTotalDistance)
+RouteSegment::RouteSegment(const RouteSegmentOptions& routeSegOptions, const std::vector<double>& normalizedPositions)
     : options_(routeSegOptions) {
-    // calculate the normalized points and the expressions
-    double currDist = 0.0;
-    for (const auto& pt : routeSegOptions.geometry) {
-        bool ptIntersectionFound = false;
-        for (size_t i = 1; i < routeGeometry.size(); ++i) {
-            const mbgl::Point<double>& pt1 = routeGeometry[i - 1];
-            const mbgl::Point<double>& pt2 = pt;
-            const mbgl::Point<double>& pt3 = routeGeometry[i];
-
-            if (isPointBetween(pt2, pt1, pt3)) {
-                double partialDist = mbgl::util::dist<double>(pt1, pt2);
-                currDist += partialDist;
-                ptIntersectionFound = true;
-                break;
-            } else {
-                currDist += routeGeomDistances[i - 1];
-            }
-        }
-
-        if (ptIntersectionFound) {
-            double normalizedDist = currDist / routeTotalDistance;
-            normalizedPositions_.push_back(normalizedDist);
-        }
-
-        currDist = 0.0;
-    }
+    normalizedPositions_ = normalizedPositions;
 }
 
 std::vector<double> RouteSegment::getNormalizedPositions() const {


### PR DESCRIPTION
Problem:
Report was made that sometimes the route segments do not closely match the traffic data in google maps.

Solution:
We need the normalized position of lat lons of route segments for gradient colors. These normalized positions were calculate in lat lon space and may not spatially accurate based on distances. This is now following the fine precision that vanishing route uses for better approximation of normalization of the lat lons along the route.

NB:
In this PR, if any route segment position has nan values , the entire route segment is rejected. The app code is sending only 2 points and we need a minimum of 2 points for a route segment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alproton/maplibre-native/36)
<!-- Reviewable:end -->
