### PR TITLE
support for enabling nav stop captures

### DIFF
--- a/include/mbgl/route/route_manager.hpp
+++ b/include/mbgl/route/route_manager.hpp
@@ -62,11 +62,8 @@ public:
 
     RouteID routeCreate(const LineString<double>& geometry, const RouteOptions& ropts);
     bool routeSegmentCreate(const RouteID&, const RouteSegmentOptions&);
-    bool routeSetProgressPercent(const RouteID&, double progress, bool capture = false);
-    double routeSetProgressPoint(const RouteID&,
-                                 const Point<double>& progressPoint,
-                                 const Precision& precision,
-                                 bool capture = false);
+    bool routeSetProgressPercent(const RouteID&, double progress);
+    double routeSetProgressPoint(const RouteID&, const Point<double>& progressPoint, const Precision& precision);
     Point<double> getPoint(const RouteID& routeID,
                            double percent,
                            const Precision& precision,
@@ -82,7 +79,7 @@ public:
     std::string getBaseGeoJSONsourceName(const RouteID& routeID) const;
     std::string captureSnapshot() const;
     int getTopMost(const std::vector<RouteID>& routeList) const;
-
+    void captureNavStops(bool onOff);
     bool hasRoutes() const;
     void finalize();
 
@@ -116,6 +113,7 @@ private:
     RouteID vanishingRouteID_;
     long long totalVanishingRouteElapsedMillis = 0;
     long long numVanisingRouteInvocations = 0;
+    bool captureNavStops_ = false;
 };
 }; // namespace route
 

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -1593,6 +1593,7 @@ void NativeMapView::registerNative(jni::JNIEnv& env) {
         METHOD(&NativeMapView::routeGetVanishing, "nativeRouteGetVanishing"),
         METHOD(&NativeMapView::routeQueryRendered, "nativeRouteQuery"),
         METHOD(&NativeMapView::routesGetCaptureSnapshot, "nativeRoutesCaptureSnapshot"),
+        METHOD(&NativeMapView::routeEnableCaptureNavStops, "nativeEnableCaptureRouteNavStops"),
         METHOD(&NativeMapView::routesFinalize, "nativeRoutesFinalize"),
         // Custom Dots API
         METHOD(&NativeMapView::setCustomDotsNextLayer, "nativeSetCustomDotsNextLayer"),
@@ -1751,6 +1752,12 @@ jboolean NativeMapView::routeSegmentCreate(JNIEnv& env,
     return false;
 }
 
+void NativeMapView::routeEnableCaptureNavStops(JNIEnv& env, jni::jboolean enable) {
+    if (routeMgr) {
+        routeMgr->captureNavStops(enable);
+    }
+}
+
 jboolean NativeMapView::routeProgressSet(JNIEnv& env, jni::jint routeID, jni::jdouble progress) {
     if (routeMgr) {
         return routeMgr->routeSetProgressPercent(RouteID(routeID), progress);
@@ -1760,11 +1767,10 @@ jboolean NativeMapView::routeProgressSet(JNIEnv& env, jni::jint routeID, jni::jd
 }
 
 jdouble NativeMapView::routeProgressSetPoint(
-    JNIEnv& env, jni::jint routeID, jni::jdouble x, jni::jdouble y, jni::jboolean coarse, jni::jboolean capture) {
+    JNIEnv& env, jni::jint routeID, jni::jdouble x, jni::jdouble y, jni::jboolean coarse) {
     if (routeMgr) {
         mbgl::route::Precision precision = coarse ? mbgl::route::Precision::Coarse : mbgl::route::Precision::Fine;
-        double percentage = routeMgr->routeSetProgressPoint(
-            RouteID(routeID), mbgl::Point<double>(x, y), precision, capture);
+        double percentage = routeMgr->routeSetProgressPoint(RouteID(routeID), mbgl::Point<double>(x, y), precision);
         return percentage;
     }
 

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
@@ -263,8 +263,7 @@ public:
 
     jboolean routeProgressSet(JNIEnv& env, jni::jint routeID, jni::jdouble progress);
 
-    jdouble routeProgressSetPoint(
-        JNIEnv& env, jni::jint routeID, jni::jdouble x, jni::jdouble y, jni::jboolean coarse, jni::jboolean capture);
+    jdouble routeProgressSetPoint(JNIEnv& env, jni::jint routeID, jni::jdouble x, jni::jdouble y, jni::jboolean coarse);
 
     void routeSegmentsClear(JNIEnv& env, jint routeID);
 
@@ -281,6 +280,8 @@ public:
     jboolean routeSetVanishing(JNIEnv& env, jni::jint routeID);
 
     jint routeGetVanishing(JNIEnv& env);
+
+    void routeEnableCaptureNavStops(JNIEnv& env, jni::jboolean enable);
     //------------------------------------------------
 
     jni::Local<jni::String> getRenderingStats(JNIEnv& env, jni::jboolean oneline);

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapView.java
@@ -64,7 +64,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   private final MapChangeReceiver mapChangeReceiver = new MapChangeReceiver();
   private final MapCallback mapCallback = new MapCallback();
   private final InitialRenderCallback initialRenderCallback = new InitialRenderCallback();
-  private boolean isPointBasedRouteQueryCoarse = true;
+  private boolean isPointBasedRouteQueryCoarse = false;
   private boolean isAutoRouteVanishing = true;
   private double latestRouteProgressPercent = 0.0;
 
@@ -524,8 +524,8 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
    * @param capture if true, the points sent downstream will be cached so that they can logged into the snapshot capture
    * @return true if successful, false otherwise. If the route does not exist, false is returned.
    */
-  public double setRouteProgressPoint(RouteID routeID, Point point, boolean coarsePrecision, boolean capture) {
-    return nativeMapView.setRouteProgressPoint(routeID, point, coarsePrecision, false);
+  public double setRouteProgressPoint(RouteID routeID, Point point, boolean coarsePrecision) {
+    return nativeMapView.setRouteProgressPoint(routeID, point, coarsePrecision);
   }
 
   /**
@@ -614,6 +614,10 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     return nativeMapView.getSnapshotCapture();
   }
 
+  public void enableCaptureRouteNavStops(boolean onOff) {
+    nativeMapView.captureRouteNavStops(onOff);
+  }
+
   /***
    * Queries map libre native is a screen space point is over a route.
    *
@@ -680,15 +684,11 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     mapRenderer.nativeSetCustomPuckState(lat, lon, bearing, iconScale, cameraTracking);
     RouteID vanishingRouteID = getVanishingRouteID();
     if(isAutoRouteVanishing && vanishingRouteID.isValid()) {
-      double percent = nativeMapView.setRouteProgressPoint(vanishingRouteID, Point.fromLngLat(lon, lat), isPointBasedRouteQueryCoarse, false);
+      double percent = nativeMapView.setRouteProgressPoint(vanishingRouteID, Point.fromLngLat(lon, lat), isPointBasedRouteQueryCoarse);
       if(percent >= 0.0 && percent <= 1.0) {
         nativeMapView.finalizeRoutes();
         latestRouteProgressPercent = percent;
       }
-
-      Timber.i("Map_View_Route_Progress: route percent: "+ percent);
-    } else {
-      Timber.i("Map_View_Route_Progress: invalid active route");
     }
 
     customPuckLatestLat = lat;

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMap.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMap.java
@@ -286,7 +286,9 @@ interface NativeMap {
 
   boolean setRouteProgress(RouteID routeID, double progress);
 
-  double setRouteProgressPoint(RouteID routeID, Point point, boolean coarsePrecision, boolean capture);
+  double setRouteProgressPoint(RouteID routeID, Point point, boolean coarsePrecision);
+
+  void captureRouteNavStops(boolean onOff);;
 
   void clearRouteSegments(RouteID routeID);
 

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
@@ -1217,13 +1217,18 @@ final class NativeMapView implements NativeMap {
   }
 
   @Override
-  public double setRouteProgressPoint(RouteID routeID, Point point, boolean coursePrecision, boolean capture) {
+  public double setRouteProgressPoint(RouteID routeID, Point point, boolean coursePrecision) {
     if(routeID.isValid()) {
       return nativeRouteSetProgressPoint(routeID.getId(), point.longitude(), point.latitude(),
-              coursePrecision, capture);
+              coursePrecision);
     }
 
     return -1.0;
+  }
+
+  @Override
+  public void captureRouteNavStops(boolean onOff) {
+    nativeEnableCaptureRouteNavStops(onOff);
   }
 
   @Override
@@ -1700,7 +1705,10 @@ final class NativeMapView implements NativeMap {
   private native boolean nativeRouteSetProgress(int routeID, double progress);
 
   @Keep
-  private native double nativeRouteSetProgressPoint(int routeID, double x, double y, boolean coursePrecision, boolean capture);
+  private native double nativeRouteSetProgressPoint(int routeID, double x, double y, boolean coursePrecision);
+
+  @Keep
+  private native void nativeEnableCaptureRouteNavStops(boolean onOff);
 
   @Keep
   private native void nativeRouteClearSegments(int routeID);

--- a/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/routes/RouteActivity.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/routes/RouteActivity.kt
@@ -49,7 +49,7 @@ class RouteActivity : AppCompatActivity(), OnMapReadyCallback {
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync(this)
         mapView.setAutoVanishingRoute(enableAutoVanishingRoute)
-
+        mapView.enableCaptureRouteNavStops(true)
         //Add route
         val addRouteButton = findViewById<Button>(R.id.add_route)
         addRouteButton?.setOnClickListener {
@@ -63,6 +63,12 @@ class RouteActivity : AppCompatActivity(), OnMapReadyCallback {
         removeRouteButton?.setOnClickListener {
             RouteUtils.disposeRoute(mapView)
             Toast.makeText(this, "Removed Route", Toast.LENGTH_SHORT).show()
+        }
+
+        val logRouteSnapshotButton = findViewById<Button>(R.id.log_route_snapshot)
+        logRouteSnapshotButton?.setOnClickListener {
+            val snapshot = mapView.getSnapshotCapture()
+            Timber.tag("ROUTE_PROGRESS").i("Route snapshot: $snapshot")
         }
 
         //route progress precision

--- a/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/routes/RouteUtils.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/routes/RouteUtils.kt
@@ -144,7 +144,7 @@ class RouteUtils {
 
             val point = routeCircle.getPoint(progress)
             Timber.tag("RouteProgress").i("getPoint: $point")
-            val calculatedPercent = mapView.setRouteProgressPoint(routeID, point, progressPrecisionCoarse, false)
+            val calculatedPercent = mapView.setRouteProgressPoint(routeID, point, progressPrecisionCoarse)
             Timber.tag("RouteProgress").i("inputPercent: $progress , calculatedPercent: $calculatedPercent")
         }
 

--- a/platform/android/MapLibreAndroidTestApp/src/main/res/layout/activity_routes.xml
+++ b/platform/android/MapLibreAndroidTestApp/src/main/res/layout/activity_routes.xml
@@ -56,6 +56,12 @@
                 />
 
         </LinearLayout>
+        <Button
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/log_route_snapshot"
+            android:text="route snapshot"
+            tools:ignore="HardcodedText"/>
 
 
     </LinearLayout>

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -1084,8 +1084,7 @@ void GLFWView::setPuckLocation(double lat, double lon, double bearing) {
     backend->setCustomPuckState(lat, lon, bearing);
     mbgl::Point<double> progressPt = {lon, lat};
     if (vanishingRouteID_.isValid()) {
-        double percent = rmptr_->routeSetProgressPoint(
-            vanishingRouteID_, progressPt, routeProgressPrecision_, captureNavPoints_);
+        double percent = rmptr_->routeSetProgressPoint(vanishingRouteID_, progressPt, routeProgressPrecision_);
         std::cout << "set puck location - percent: " << std::to_string(percent) << std::endl;
     }
 }
@@ -1324,7 +1323,7 @@ void GLFWView::incrementRouteProgress() {
             vanishingRouteID_, routeProgress_, routeProgressPrecision_, &bearing);
 
         if (!enableAutoVanishing) {
-            rmptr_->routeSetProgressPoint(vanishingRouteID_, progressPoint, routeProgressPrecision_, captureNavPoints_);
+            rmptr_->routeSetProgressPoint(vanishingRouteID_, progressPoint, routeProgressPrecision_);
             // std::cout << "Route progress: " << std::to_string(routeProgress_) << ", calculated percent: " <<
             // std::to_string(percentage) << std::endl;
             rmptr_->finalize();
@@ -1346,7 +1345,7 @@ void GLFWView::decrementRouteProgress() {
             vanishingRouteID_, routeProgress_, routeProgressPrecision_, &bearing);
 
         if (!enableAutoVanishing) {
-            rmptr_->routeSetProgressPoint(vanishingRouteID_, progressPoint, routeProgressPrecision_, captureNavPoints_);
+            rmptr_->routeSetProgressPoint(vanishingRouteID_, progressPoint, routeProgressPrecision_);
             rmptr_->finalize();
         }
         setPuckLocation(progressPoint.y, progressPoint.x, bearing);

--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -207,7 +207,6 @@ private:
     bool loadedCapture_ = false;
     double routeProgress_ = 0.0;
     bool routePickMode_ = false;
-    bool captureNavPoints_ = true;
     bool enableAutoVanishing = false; // Simulates route progress in app
     mbgl::route::Precision routePrecision_ = mbgl::route::Precision::Fine;
 

--- a/src/mbgl/route/route.cpp
+++ b/src/mbgl/route/route.cpp
@@ -689,7 +689,7 @@ double Route::getProgressProjectionSLERP(const Point<double>& queryPoint, bool c
     }
 
     // Handle zero-length route
-    if (totalLength_ <= EPSILON) {
+    if (totalLength_ <= std::numeric_limits<double>::epsilon()) {
         // If the route has no length, the closest point is the first point,
         // and percentage is arguably 0 or undefined. We'll return 0.
         // Check if query point *is* the single point location
@@ -719,7 +719,7 @@ double Route::getProgressProjectionSLERP(const Point<double>& queryPoint, bool c
         double segmentLenSq = vecMagnitudeSq(segmentVec);
         double t = 0.0; // Parameter along the chord (0=v1, 1=v2)
 
-        if (segmentLenSq > EPSILON) {
+        if (segmentLenSq > std::numeric_limits<double>::epsilon()) {
             // Project queryVec onto segmentVec
             t = vecDot(queryVec, segmentVec) / segmentLenSq;
             t = std::clamp(t, 0.0, 1.0); // Clamp to the segment bounds [0, 1]
@@ -739,7 +739,8 @@ double Route::getProgressProjectionSLERP(const Point<double>& queryPoint, bool c
         dot_prod = std::clamp(dot_prod, -1.0, 1.0); // Clamp for acos safety
         omega = std::acos(dot_prod);                // Angle of the arc segment
 
-        if (std::abs(omega) < EPSILON || std::abs(std::sin(omega)) < EPSILON) {
+        if (std::abs(omega) < std::numeric_limits<double>::epsilon() ||
+            std::abs(std::sin(omega)) < std::numeric_limits<double>::epsilon()) {
             // Arc angle is negligible (points identical) or antipodal.
             // If identical (omega ~ 0), the point is just p1 (or p2).
             // If antipodal (omega ~ PI), the path is ambiguous, but LERP is okay fallback.

--- a/src/mbgl/route/route_manager.cpp
+++ b/src/mbgl/route/route_manager.cpp
@@ -436,6 +436,10 @@ bool RouteManager::routeSegmentCreate(const RouteID& routeID, const RouteSegment
     return false;
 }
 
+void RouteManager::captureNavStops(bool onOff) {
+    captureNavStops_ = onOff;
+}
+
 void RouteManager::validateAddToDirtyBin(const RouteID& routeID, const DirtyType& dirtyBin) {
     // check if this route is in the list of dirty geometry routes. if so, then no need to set dirty segments, as it
     // will be created during finalize
@@ -517,13 +521,13 @@ bool RouteManager::hasRoutes() const {
     return !routeMap_.empty();
 }
 
-bool RouteManager::routeSetProgressPercent(const RouteID& routeID, const double progress, bool capture) {
+bool RouteManager::routeSetProgressPercent(const RouteID& routeID, const double progress) {
     assert(style_ != nullptr && "Style not set!");
     assert(routeID.isValid() && "invalid route ID");
     double validProgress = std::clamp(progress, 0.0, 1.0);
     bool success = false;
     if (routeID.isValid() && routeMap_.find(routeID) != routeMap_.end()) {
-        routeMap_[routeID].routeSetProgress(validProgress, capture);
+        routeMap_[routeID].routeSetProgress(validProgress, captureNavStops_);
         validateAddToDirtyBin(routeID, DirtyType::dtRouteProgress);
 
         success = true;
@@ -534,15 +538,14 @@ bool RouteManager::routeSetProgressPercent(const RouteID& routeID, const double 
 
 double RouteManager::routeSetProgressPoint(const RouteID& routeID,
                                            const mbgl::Point<double>& progressPoint,
-                                           const Precision& precision,
-                                           bool capture) {
+                                           const Precision& precision) {
     assert(routeID.isValid() && "invalid route ID");
     double percentage = -1.0;
     if (routeID.isValid() && routeMap_.find(routeID) != routeMap_.end()) {
         auto startTime = std::chrono::high_resolution_clock::now();
         {
             if (routeID.isValid() && routeMap_.find(routeID) != routeMap_.end()) {
-                percentage = routeMap_.at(routeID).getProgressPercent(progressPoint, precision, capture);
+                percentage = routeMap_.at(routeID).getProgressPercent(progressPoint, precision, captureNavStops_);
             }
         }
         auto endTime = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
This PR enables the following:
* refactored removing of capture flag when calling set progress 
* introduced a new API that allows to capture nav stops global to route manager (instead of per function basis)
* changed epsilon in fine precision to system level smaller values - we need to test this in the case of sharp u-turns when two lanes are very close to each other (in feet or may be even inches)
