### PR TITLE
Add background color for missing tiles

### DIFF
--- a/include/mbgl/renderer/renderer.hpp
+++ b/include/mbgl/renderer/renderer.hpp
@@ -114,6 +114,7 @@ public:
     void addTileCacheSettings(const TileCacheSettings& settings);
     void reduceMemoryUse();
     void clearData();
+    void onStyleChange();
 
 #if MLN_RENDER_BACKEND_OPENGL
     void enableAndroidEmulatorGoldfishMitigation(bool enable);

--- a/include/mbgl/renderer/tile_cache_settings.hpp
+++ b/include/mbgl/renderer/tile_cache_settings.hpp
@@ -9,6 +9,8 @@ struct TileCacheSettings {
     std::string source;           // The tile source ID
     int minTiles = 0;             // The computed tile cache size is clamped between minTiles and maxTiles
     int maxTiles = 0;             // The computed tile cache size is clamped between minTiles and maxTiles
+    int minZoom = 0;              // The minimum zoom level for the tile cache
+    int maxZoom = 32;             // The maximum zoom level for the tile cache
     bool aggressiveCache = false; // If true, tiles that are not ideal are also cached. Check update_renderables.hpp for
                                   // details about ideal tiles.
     bool skipRelayoutClear =

--- a/platform/android/MapLibreAndroid/src/cpp/android_renderer_frontend.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/android_renderer_frontend.cpp
@@ -4,6 +4,7 @@
 #include <mbgl/actor/scheduler.hpp>
 #include <mbgl/renderer/renderer.hpp>
 #include <mbgl/renderer/renderer_observer.hpp>
+#include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/util/async_task.hpp>
 #include <mbgl/util/geojson.hpp>
 #include <mbgl/util/instrumentation.hpp>
@@ -116,6 +117,9 @@ void AndroidRendererFrontend::setObserver(RendererObserver& observer) {
 void AndroidRendererFrontend::update(std::shared_ptr<UpdateParameters> params) {
     MLN_TRACE_FUNC();
     updateParams = std::move(params);
+    if (updateParams) {
+        updateParams->backgroundClearColor = backgroundClearColor;
+    }
     updateAsyncTask->send();
 }
 
@@ -141,6 +145,10 @@ void AndroidRendererFrontend::reduceMemoryUse() {
 
 void AndroidRendererFrontend::clearData() {
     mapRenderer.actor().invoke(&Renderer::clearData);
+}
+
+void AndroidRendererFrontend::onStyleChange() {
+    mapRenderer.actor().invoke(&Renderer::onStyleChange);
 }
 
 std::vector<Feature> AndroidRendererFrontend::querySourceFeatures(const std::string& sourceID,

--- a/platform/android/MapLibreAndroid/src/cpp/android_renderer_frontend.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/android_renderer_frontend.hpp
@@ -4,11 +4,13 @@
 #include <mbgl/annotation/annotation.hpp>
 #include <mbgl/renderer/renderer_frontend.hpp>
 #include <mbgl/renderer/tile_cache_settings.hpp>
+#include <mbgl/util/color.hpp>
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/run_loop.hpp>
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <vector>
 #include <string>
 #include <mbgl/util/geojson.hpp>
@@ -34,6 +36,7 @@ public:
     ~AndroidRendererFrontend() override;
 
     void clearData();
+    void onStyleChange();
 
     void reset() override;
     void setObserver(RendererObserver&) override;
@@ -62,11 +65,14 @@ public:
     void addTileCacheSettings(const TileCacheSettings& settings);
     void reduceMemoryUse();
 
+    void setBackgroundClearColor(const Color& color) { backgroundClearColor = color; }
+
 private:
     MapRenderer& mapRenderer;
     util::RunLoop* mapRunLoop;
     std::unique_ptr<util::AsyncTask> updateAsyncTask;
     std::shared_ptr<UpdateParameters> updateParams;
+    std::optional<Color> backgroundClearColor;
 };
 
 } // namespace android

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -326,7 +326,7 @@ jni::Local<jni::String> NativeMapView::getStyleUrl(jni::JNIEnv& env) {
 
 void NativeMapView::setStyleUrl(jni::JNIEnv& env, const jni::String& url) {
     if (rendererFrontend) {
-        rendererFrontend->clearData();
+        rendererFrontend->onStyleChange();
     }
     map->getStyle().loadURL(jni::Make<std::string>(env, url));
     if (routeMgr) {
@@ -340,7 +340,7 @@ jni::Local<jni::String> NativeMapView::getStyleJson(jni::JNIEnv& env) {
 
 void NativeMapView::setStyleJson(jni::JNIEnv& env, const jni::String& json) {
     if (rendererFrontend) {
-        rendererFrontend->clearData();
+        rendererFrontend->onStyleChange();
     }
     map->getStyle().loadJSON(jni::Make<std::string>(env, json));
     if (routeMgr) {
@@ -1352,15 +1352,27 @@ void NativeMapView::addTileCacheSettings(JNIEnv& env,
                                          const jni::String& source,
                                          jni::jint minTiles,
                                          jni::jint maxTiles,
+                                         jni::jint minZoom,
+                                         jni::jint maxZoom,
                                          jni::jboolean aggressiveCache,
                                          jni::jboolean skipRelayoutClear) {
     mbgl::TileCacheSettings settings{};
     settings.source = jni::Make<std::string>(env, source);
     settings.minTiles = minTiles;
     settings.maxTiles = maxTiles;
+    settings.minZoom = minZoom;
+    settings.maxZoom = maxZoom;
     settings.aggressiveCache = aggressiveCache == jni::jni_true;
     settings.skipRelayoutClear = skipRelayoutClear == jni::jni_true;
     rendererFrontend->addTileCacheSettings(settings);
+}
+
+void NativeMapView::setBackgroundClearColor(JNIEnv& env, jni::jint color) {
+    conversion::Converter<mbgl::Color, int> colorConverter;
+    auto c = colorConverter(env, color);
+    if (c) {
+        rendererFrontend->setBackgroundClearColor(*c);
+    }
 }
 
 void NativeMapView::setTileLodMinRadius(JNIEnv&, jni::jdouble radius) {
@@ -1570,6 +1582,7 @@ void NativeMapView::registerNative(jni::JNIEnv& env) {
         METHOD(&NativeMapView::setTileCacheEnabled, "nativeSetTileCacheEnabled"),
         METHOD(&NativeMapView::getTileCacheEnabled, "nativeGetTileCacheEnabled"),
         METHOD(&NativeMapView::addTileCacheSettings, "nativeAddTileCacheSettings"),
+        METHOD(&NativeMapView::setBackgroundClearColor, "nativeSetBackgroundClearColor"),
         METHOD(&NativeMapView::triggerRepaint, "nativeTriggerRepaint"),
         METHOD(&NativeMapView::setTileLodMinRadius, "nativeSetTileLodMinRadius"),
         METHOD(&NativeMapView::getTileLodMinRadius, "nativeGetTileLodMinRadius"),

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
@@ -362,7 +362,10 @@ public:
 
     jni::jboolean getTileCacheEnabled(JNIEnv&);
 
-    void addTileCacheSettings(JNIEnv&, const jni::String&, jni::jint, jni::jint, jni::jboolean, jni::jboolean);
+    void addTileCacheSettings(
+        JNIEnv&, const jni::String&, jni::jint, jni::jint, jni::jint, jni::jint, jni::jboolean, jni::jboolean);
+
+    void setBackgroundClearColor(JNIEnv&, jni::jint);
 
     void setTileLodMinRadius(JNIEnv&, jni::jdouble);
 

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/SymbolLocationLayerRenderer.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/SymbolLocationLayerRenderer.java
@@ -245,6 +245,10 @@ final class SymbolLocationLayerRenderer implements LocationLayerRenderer {
   }
 
   private void setLayerVisibility(@NonNull String layerId, boolean visible) {
+    if (!style.isFullyLoaded()) {
+      // workaround for https://github.com/maplibre/maplibre-native/issues/3506
+      return; // Application will set the right visibility after the style is loaded
+    }
     Layer layer = style.getLayer(layerId);
     if (layer != null) {
       String targetVisibility = visible ? VISIBLE : NONE;

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapLibreMap.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapLibreMap.java
@@ -353,6 +353,14 @@ public final class MapLibreMap {
     nativeMapView.addTileCacheSettings(settings);
   }
 
+   /**
+   * Set background color for missing vector tiles
+   *
+   */
+  public void setBackgroundClearColor(int color) {
+    nativeMapView.setBackgroundClearColor(color);
+  }
+
   /**
    * Camera based tile level of detail controls
    *

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMap.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMap.java
@@ -243,6 +243,8 @@ interface NativeMap {
 
   void addTileCacheSettings(TileCacheSettings settings);
 
+  void setBackgroundClearColor(int color);
+
   void setTileLodMinRadius(double radius);
 
   double getTileLodMinRadius();

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
@@ -840,8 +840,18 @@ final class NativeMapView implements NativeMap {
     nativeAddTileCacheSettings(settings.source,
                                settings.minTiles,
                                settings.maxTiles,
+                               settings.minZoom,
+                               settings.maxZoom,
                                settings.aggressiveCache,
                                settings.skipRelayoutClear);
+  }
+
+  @Override
+  public void setBackgroundClearColor(int color) {
+    if (checkState("setBackgroundClearColor")) {
+      return;
+    }
+    nativeSetBackgroundClearColor(color);
   }
 
   @Override
@@ -1949,8 +1959,13 @@ final class NativeMapView implements NativeMap {
   private native void nativeAddTileCacheSettings(String source,
                                                  int minTiles,
                                                  int maxTiles,
+                                                 int minZoom,
+                                                 int maxZoom,
                                                  boolean aggressiveCache,
                                                  boolean skipRelayoutClear);
+
+  @Keep
+  private native void nativeSetBackgroundClearColor(int color);
 
   @Keep
   private native int nativeGetPrefetchZoomDelta();

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/TileCacheSettings.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/TileCacheSettings.java
@@ -17,6 +17,16 @@ final public class TileCacheSettings {
     public int maxTiles;
 
     /***
+     * Zoom below minZoom will not be cached
+     */
+    public int minZoom;
+
+    /***
+     * Zoom above maxZoom will not be cached
+     */
+    public int maxZoom;
+
+    /***
      * If true, tiles that are not ideal are also cached
      * Check update_renderables.hpp for details about ideal tiles
      */

--- a/src/mbgl/map/map_impl.cpp
+++ b/src/mbgl/map/map_impl.cpp
@@ -103,7 +103,8 @@ void Map::Impl::onUpdate() {
                                tileLodMinRadius,
                                tileLodScale,
                                tileLodPitchThreshold,
-                               tileLodZoomShift};
+                               tileLodZoomShift,
+                               std::nullopt};
 
     rendererFrontend.update(std::make_shared<UpdateParameters>(std::move(params)));
 }

--- a/src/mbgl/renderer/layers/render_background_layer.hpp
+++ b/src/mbgl/renderer/layers/render_background_layer.hpp
@@ -23,6 +23,8 @@ public:
     explicit RenderBackgroundLayer(Immutable<style::BackgroundLayer::Impl>);
     ~RenderBackgroundLayer() override;
 
+    void setBackGroundRenderTiles(std::vector<RenderTiles> tiles) override { backgroundRenderTiles = std::move(tiles); }
+
 #if MLN_DRAWABLE_RENDERER
     /// Generate any changes needed by the layer
     void update(gfx::ShaderRegistry&,

--- a/src/mbgl/renderer/layers/render_fill_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.hpp
@@ -36,6 +36,8 @@ public:
     explicit RenderFillLayer(Immutable<style::FillLayer::Impl>);
     ~RenderFillLayer() override;
 
+    RenderTiles getBackGroundRenderTiles() const override { return renderTiles; }
+
 #if MLN_DRAWABLE_RENDERER
     /// Generate any changes needed by the layer
     void update(gfx::ShaderRegistry&,

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -96,6 +96,10 @@ protected:
 public:
     virtual ~RenderLayer() = default;
 
+    virtual RenderTiles getBackGroundRenderTiles() const { return nullptr; }
+
+    virtual void setBackGroundRenderTiles(std::vector<RenderTiles>) {}
+
     // Begin transitions for any properties that have changed since the last frame.
     virtual void transition(const TransitionParameters&) = 0;
 
@@ -278,6 +282,7 @@ protected:
 protected:
     // Stores current set of tiles to be rendered for this layer.
     RenderTiles renderTiles;
+    std::vector<RenderTiles> backgroundRenderTiles;
 
     // Retains ownership of tiles
     Immutable<std::vector<RenderTile>> renderTilesOwner;

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -416,7 +416,9 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
             if (layerIsVisible && zoomFitsLayer && sourceImpl.get() == sourceImpls->at(0).get()) {
                 if (backgroundLayerAsColor && layer.baseImpl == layerImpls->front()) {
                     const auto& solidBackground = layer.getSolidBackground();
-                    if (solidBackground) {
+                    if (updateParameters->backgroundClearColor) {
+                        renderTreeParameters->backgroundColor = *updateParameters->backgroundClearColor;
+                    } else if (solidBackground) {
                         renderTreeParameters->backgroundColor = *solidBackground;
                         continue; // This layer is shown with background color,
                                   // and it shall not be added to render items.
@@ -875,6 +877,14 @@ bool RenderOrchestrator::isLoaded() const {
     return true;
 }
 
+void RenderOrchestrator::onStyleChange() {
+    MLN_TRACE_FUNC();
+
+    for (auto& source : renderSources) {
+        source.second->onStyleChange();
+    }
+}
+
 void RenderOrchestrator::clearData() {
     MLN_TRACE_FUNC();
 
@@ -993,6 +1003,21 @@ void RenderOrchestrator::updateLayers(gfx::ShaderRegistry& shaders,
 
     std::vector<std::unique_ptr<ChangeRequest>> changes;
     changes.reserve(items.size() * 3);
+
+    if (updateParameters->backgroundClearColor) {
+        std::vector<RenderTiles> backgroundRenderTiles;
+        for (const auto& item : items) {
+            const auto& renderLayer = item.layer.get();
+            RenderTiles tiles = renderLayer.getBackGroundRenderTiles();
+            if (tiles != nullptr) {
+                backgroundRenderTiles.push_back(std::move(tiles));
+            }
+        }
+        for (const auto& item : items) {
+            auto& renderLayer = item.layer.get();
+            renderLayer.setBackGroundRenderTiles(backgroundRenderTiles);
+        }
+    }
 
     for (const auto& item : items) {
         auto& renderLayer = item.layer.get();

--- a/src/mbgl/renderer/render_orchestrator.hpp
+++ b/src/mbgl/renderer/render_orchestrator.hpp
@@ -105,6 +105,7 @@ public:
     void collectPlacedSymbolData(bool);
     const std::vector<PlacedSymbolData>& getPlacedSymbolsData() const;
     void clearData();
+    void onStyleChange();
 
     void update(const std::shared_ptr<UpdateParameters>&);
 

--- a/src/mbgl/renderer/render_source.hpp
+++ b/src/mbgl/renderer/render_source.hpp
@@ -113,6 +113,8 @@ public:
 
     virtual uint8_t getMaxZoom() const;
 
+    virtual void onStyleChange() {};
+
     void setObserver(RenderSourceObserver*);
 
     Immutable<style::Source::Impl> baseImpl;

--- a/src/mbgl/renderer/renderer.cpp
+++ b/src/mbgl/renderer/renderer.cpp
@@ -162,6 +162,10 @@ void Renderer::clearData() {
     reduceMemoryUse();
 }
 
+void Renderer::onStyleChange() {
+    impl->orchestrator.onStyleChange();
+}
+
 #if MLN_RENDER_BACKEND_OPENGL
 void Renderer::enableAndroidEmulatorGoldfishMitigation(bool enable) {
     impl->orchestrator.enableAndroidEmulatorGoldfishMitigation(enable);

--- a/src/mbgl/renderer/sources/render_tile_source.hpp
+++ b/src/mbgl/renderer/sources/render_tile_source.hpp
@@ -54,6 +54,8 @@ public:
     void reduceMemoryUse() override;
     void dumpDebugLogs() const override;
 
+    void onStyleChange() override { tilePyramid.onStyleChange(); }
+
 protected:
     RenderTileSource(Immutable<style::Source::Impl>, const TaggedScheduler&);
     TilePyramid tilePyramid;

--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -436,6 +436,7 @@ void TilePyramid::updateTileCacheSettings(const TileCacheSettingsMap& settings) 
     }
     assert(cache.getSource() == it->second.source);
     cache.updateSizeRange(it->second.minTiles, it->second.maxTiles);
+    cache.updateZoomRange(it->second.minZoom, it->second.maxZoom);
     aggressiveTileCache = it->second.aggressiveCache;
     skipRelayoutClear = it->second.skipRelayoutClear;
 }

--- a/src/mbgl/renderer/tile_pyramid.hpp
+++ b/src/mbgl/renderer/tile_pyramid.hpp
@@ -75,6 +75,12 @@ public:
     void updateFadingTiles();
     bool hasFadingTiles() const { return fadingTiles; }
 
+    void onStyleChange() {
+        if (skipRelayoutClear) {
+            clearAll();
+        }
+    }
+
 private:
     void addRenderTile(const UnwrappedTileID& tileID, Tile& tile);
 

--- a/src/mbgl/renderer/update_parameters.hpp
+++ b/src/mbgl/renderer/update_parameters.hpp
@@ -8,9 +8,11 @@
 #include <mbgl/style/source.hpp>
 #include <mbgl/style/layer.hpp>
 #include <mbgl/util/chrono.hpp>
+#include <mbgl/util/color.hpp>
 #include <mbgl/util/immutable.hpp>
 
 #include <numbers>
+#include <optional>
 #include <vector>
 
 #include <mapbox/std/weak.hpp>
@@ -51,6 +53,8 @@ public:
     double tileLodScale = 1;
     double tileLodPitchThreshold = (60.0 / 180.0) * std::numbers::pi;
     MapLodShift tileLodZoomShift;
+
+    std::optional<Color> backgroundClearColor;
 };
 
 } // namespace mbgl

--- a/src/mbgl/tile/tile_cache.cpp
+++ b/src/mbgl/tile/tile_cache.cpp
@@ -106,7 +106,7 @@ void TileCache::deferPendingReleases() {
 void TileCache::add(const OverscaledTileID& key, std::unique_ptr<Tile>&& tile) {
     MLN_TRACE_FUNC();
 
-    if (!tile->isRenderable() || !size) {
+    if (!tile->isRenderable() || !size || tile->id.overscaledZ < minZoom || tile->id.overscaledZ > maxZoom) {
         deferredRelease(std::move(tile));
         return;
     }

--- a/src/mbgl/tile/tile_cache.hpp
+++ b/src/mbgl/tile/tile_cache.hpp
@@ -46,6 +46,11 @@ public:
         maxSize = maxSize_;
     }
 
+    void updateZoomRange(size_t minZoom_, size_t maxZoom_) {
+        minZoom = minZoom_;
+        maxZoom = maxZoom_;
+    }
+
     void setSource(std::string source_) { source = std::move(source_); }
 
     const std::string& getSource() const noexcept { return source; }
@@ -61,6 +66,8 @@ private:
     size_t size;
     size_t minSize = 0;
     size_t maxSize = 65536;
+    int minZoom = 0;
+    int maxZoom = 32;
     std::string source = "";
 };
 


### PR DESCRIPTION
When a tile is missing (being downloaded) the background color defined in the style is used. This PR adds the possibility to define another background color set using the API `setBackgroundClearColor`. When the tile is available the style background color is used otherwise the color set with `setBackgroundClearColor` is used for missing tiles

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alproton/maplibre-native/39)
<!-- Reviewable:end -->
