### PR TITLE
Add an option to un-cache old tiles to reduce memory usage

### DIFF
--- a/include/mbgl/renderer/tile_cache_settings.hpp
+++ b/include/mbgl/renderer/tile_cache_settings.hpp
@@ -11,6 +11,7 @@ struct TileCacheSettings {
     int maxTiles = 0;             // The computed tile cache size is clamped between minTiles and maxTiles
     int minZoom = 0;              // The minimum zoom level for the tile cache
     int maxZoom = 32;             // The maximum zoom level for the tile cache
+    double cachedTileMaxAge = 0;  // The maximum age of cached tiles in seconds. If 0, no tiles are removed based on age
     bool aggressiveCache = false; // If true, tiles that are not ideal are also cached. Check update_renderables.hpp for
                                   // details about ideal tiles.
     bool skipRelayoutClear =

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -1354,6 +1354,7 @@ void NativeMapView::addTileCacheSettings(JNIEnv& env,
                                          jni::jint maxTiles,
                                          jni::jint minZoom,
                                          jni::jint maxZoom,
+                                         jni::jdouble cachedTileMaxAge,
                                          jni::jboolean aggressiveCache,
                                          jni::jboolean skipRelayoutClear) {
     mbgl::TileCacheSettings settings{};
@@ -1362,6 +1363,7 @@ void NativeMapView::addTileCacheSettings(JNIEnv& env,
     settings.maxTiles = maxTiles;
     settings.minZoom = minZoom;
     settings.maxZoom = maxZoom;
+    settings.cachedTileMaxAge = cachedTileMaxAge;
     settings.aggressiveCache = aggressiveCache == jni::jni_true;
     settings.skipRelayoutClear = skipRelayoutClear == jni::jni_true;
     rendererFrontend->addTileCacheSettings(settings);

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
@@ -369,8 +369,15 @@ public:
 
     jni::jboolean getTileCacheEnabled(JNIEnv&);
 
-    void addTileCacheSettings(
-        JNIEnv&, const jni::String&, jni::jint, jni::jint, jni::jint, jni::jint, jni::jboolean, jni::jboolean);
+    void addTileCacheSettings(JNIEnv&,
+                              const jni::String&,
+                              jni::jint,
+                              jni::jint,
+                              jni::jint,
+                              jni::jint,
+                              jni::jdouble,
+                              jni::jboolean,
+                              jni::jboolean);
 
     void setBackgroundClearColor(JNIEnv&, jni::jint);
 

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
@@ -842,6 +842,7 @@ final class NativeMapView implements NativeMap {
                                settings.maxTiles,
                                settings.minZoom,
                                settings.maxZoom,
+                               settings.cachedTileMaxAge,
                                settings.aggressiveCache,
                                settings.skipRelayoutClear);
   }
@@ -1986,6 +1987,7 @@ final class NativeMapView implements NativeMap {
                                                  int maxTiles,
                                                  int minZoom,
                                                  int maxZoom,
+                                                 double cachedTileMaxAge,
                                                  boolean aggressiveCache,
                                                  boolean skipRelayoutClear);
 

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/TileCacheSettings.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/TileCacheSettings.java
@@ -27,6 +27,12 @@ final public class TileCacheSettings {
     public int maxZoom;
 
     /***
+     * The maximum age of cached tiles in seconds
+     * If 0, no tiles are removed based on age
+     */
+    public double cachedTileMaxAge;
+
+    /***
      * If true, tiles that are not ideal are also cached
      * Check update_renderables.hpp for details about ideal tiles
      */

--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -437,6 +437,7 @@ void TilePyramid::updateTileCacheSettings(const TileCacheSettingsMap& settings) 
     assert(cache.getSource() == it->second.source);
     cache.updateSizeRange(it->second.minTiles, it->second.maxTiles);
     cache.updateZoomRange(it->second.minZoom, it->second.maxZoom);
+    cache.updateCachedTileMaxAge(it->second.cachedTileMaxAge);
     aggressiveTileCache = it->second.aggressiveCache;
     skipRelayoutClear = it->second.skipRelayoutClear;
 }


### PR DESCRIPTION
Option to reduce tile cache memory usage

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alproton/maplibre-native/44)
<!-- Reviewable:end -->
