### PR TITLE
Early out from releaseOldTiles

### DIFF
--- a/src/mbgl/tile/tile_cache.cpp
+++ b/src/mbgl/tile/tile_cache.cpp
@@ -175,7 +175,7 @@ void TileCache::clear() {
 }
 
 void TileCache::releaseOldTiles() {
-    if (cachedTileMaxAge <= 0) {
+    if (cachedTileMaxAge <= 0 || tileStamps.empty()) {
         return;
     }
     auto maxAge = std::chrono::duration<double>(cachedTileMaxAge);
@@ -183,10 +183,12 @@ void TileCache::releaseOldTiles() {
     if (now - oldestTile < maxAge) {
         return;
     }
+    oldestTile = now;
     std::vector<OverscaledTileID> keysToRemove;
     for (const auto& [key, stamp] : tileStamps) {
         if (now - stamp >= maxAge) {
             keysToRemove.push_back(key);
+        } else {
             oldestTile = std::min(oldestTile, stamp);
         }
     }


### PR DESCRIPTION
There was a minor performance bug in https://github.com/alproton/maplibre-native/pull/44 causing `releaseOldTiles` to never early out and compute `oldestTile` timestamp every frame.
This change ensures `oldestTile` is initialized before computing the oldest tile timestamp.
After this change when `cachedTileMaxAge` is to set to a value, e.g. 1 minute, `releaseOldTiles` will execute its code every minute on average

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alproton/maplibre-native/45)
<!-- Reviewable:end -->
