### PR TITLE
Fix regression related to storing bad puck  initial tracking state

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationAnimatorCustomPuck.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationAnimatorCustomPuck.java
@@ -102,23 +102,22 @@ final class LocationAnimatorCustomPuck {
           targetPuckLocation = new StampedLatLon(currentPuckLocation);
         }
 
-        // Make sure the style is loaded before rendering the puck
-        if (mapView == null
-            || mapView.getMapLibreMap() == null
-            || mapView.getMapLibreMap().getStyle() == null
-            || !mapView.getMapLibreMap().getStyle().isFullyLoaded()) {
-          return;
-        }
-
         // Get a handler that can be used to post to the main thread
         Handler mainHandler = new Handler(context.getMainLooper());
 
         Runnable myRunnable = new Runnable() {
           @Override
           public void run() {
-            locationLayerRenderer.setLatLng(new LatLng(location.lat, location.lon));
-            locationLayerRenderer.setGpsBearing((float)(location.bearing));
-            locationLayerRenderer.hide();
+            // Make sure the style is loaded before using locationLayerRenderer
+            if (mapView != null
+                && mapView.getMapLibreMap() != null
+                && mapView.getMapLibreMap().getStyle() != null
+                && mapView.getMapLibreMap().getStyle().isFullyLoaded()) {
+              locationLayerRenderer.setLatLng(new LatLng(location.lat, location.lon));
+              locationLayerRenderer.setGpsBearing((float)(location.bearing));
+              locationLayerRenderer.hide();
+            }
+
             if (locationCameraController.isLocationTracking()) {
               locationCameraController.setLatLng(new LatLng(location.lat, location.lon));
             }
@@ -131,13 +130,15 @@ final class LocationAnimatorCustomPuck {
             }
 
             boolean tracking = locationCameraController.isLocationTracking() && !locationCameraController.isTransitioning();
-            mapView.setCustomPuckState(
-              location.lat,
-              location.lon,
-              location.bearing,
-              customPuckAnimationOptions.iconScale,
-              tracking);
-          }
+            if (mapView != null) {
+                mapView.setCustomPuckState(
+                location.lat,
+                location.lon,
+                location.bearing,
+                customPuckAnimationOptions.iconScale,
+                tracking);
+              }
+            }
         };
         mainHandler.post(myRunnable);
       }


### PR DESCRIPTION
[This PR](https://github.com/alproton/maplibre-native/pull/30) introduced a regression where we don't call `mapView.setCustomPuckState` when `mapView` is not null and the style is not fully loaded yet. This change the puck has a good initial state as soon as `mapView` is valid. This way the puck is correctly placed at initialization

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alproton/maplibre-native/49)
<!-- Reviewable:end -->
