### PR TITLE
Fix tile cache dangling reference

### DIFF
--- a/src/mbgl/renderer/tile_parameters.hpp
+++ b/src/mbgl/renderer/tile_parameters.hpp
@@ -32,7 +32,7 @@ public:
     double tileLodMinRadius = 3;
     double tileLodScale = 1;
     double tileLodPitchThreshold = (60.0 / 180.0) * std::numbers::pi;
-    MapLodShift tileLodZoomShift;
+    MapLodShift tileLodZoomShift = {};
 };
 
 } // namespace mbgl

--- a/src/mbgl/tile/tile_cache.cpp
+++ b/src/mbgl/tile/tile_cache.cpp
@@ -145,7 +145,7 @@ Tile* TileCache::get(const OverscaledTileID& key) {
     }
 }
 
-std::unique_ptr<Tile> TileCache::pop(const OverscaledTileID& key) {
+std::unique_ptr<Tile> TileCache::pop(OverscaledTileID key) {
     std::unique_ptr<Tile> tile;
 
     const auto it = tiles.find(key);

--- a/src/mbgl/tile/tile_cache.hpp
+++ b/src/mbgl/tile/tile_cache.hpp
@@ -32,7 +32,7 @@ public:
     /// If a tile with the same ID is already present, it will be retained and the new one will be discarded.
     void add(const OverscaledTileID& key, std::unique_ptr<Tile>&& tile);
 
-    std::unique_ptr<Tile> pop(const OverscaledTileID& key);
+    std::unique_ptr<Tile> pop(OverscaledTileID key);
     Tile* get(const OverscaledTileID& key);
     bool has(const OverscaledTileID& key);
     void clear();


### PR DESCRIPTION
This avoids a dangling pointer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alproton/maplibre-native/53)
<!-- Reviewable:end -->
