### PR TITLE
Sid revert highp linesofar

### DIFF
--- a/include/mbgl/gfx/polyline_generator.hpp
+++ b/include/mbgl/gfx/polyline_generator.hpp
@@ -122,7 +122,7 @@ private:
     CreateSegmentFunc createSegment;
     GetSegmentFunc getSegment;
     Indexes& indexes;
-    const bool logVertices = false;
+    const bool logVertices = true;
 
     std::ptrdiff_t e1;
     std::ptrdiff_t e2;

--- a/include/mbgl/gfx/polyline_generator.hpp
+++ b/include/mbgl/gfx/polyline_generator.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "mbgl/tile/tile_id.hpp"
-
 #include <mbgl/util/geometry.hpp>
 #include <mbgl/tile/geometry_tile_data.hpp>
 #include <mbgl/style/types.hpp>
@@ -29,8 +27,6 @@ public:
 
     // Scale line distance from tile units to [0, 2^15).
     double scaleToMaxLineDistance(double tileDistance) const;
-    double unscaledDistance(double tileDistance) const;
-    double routeDistance(double routeDistanceSoFar, double totalRouteDistance) const;
 
 public:
     double clipStart;
@@ -47,25 +43,6 @@ struct PolylineGeneratorOptions {
     float roundLimit{1.f};
     uint32_t overscaling{1};
     std::optional<PolylineGeneratorDistances> clipDistances;
-    bool isRoutePath = false;
-    double totalInMeters;
-    CanonicalTileID canonicalTileID = CanonicalTileID(0, 0, 0);
-
-    Point<double> tileCoordinatesToLatLng(const Point<int16_t>& p) const {
-        // assert(canonicalTileID.z != (~0) && canonicalTileID.x != (~0) && canonicalTileID.y != (~0));
-        const double size = util::EXTENT * std::pow(2, canonicalTileID.z);
-        const double x0 = util::EXTENT * static_cast<double>(canonicalTileID.x);
-        const double y0 = util::EXTENT * static_cast<double>(canonicalTileID.y);
-
-        double y2 = 180 - (p.y + y0) * 360 / size;
-        return Point<double>((p.x + x0) * 360 / size - 180, std::atan(std::exp(y2 * M_PI / 180)) * 360.0 / M_PI - 90.0);
-    }
-
-    double haversineDist(const GeometryCoordinate& g0, const GeometryCoordinate& g1) const {
-        Point<double> p0 = tileCoordinatesToLatLng(g0);
-        Point<double> p1 = tileCoordinatesToLatLng(g1);
-        return util::haversineDist(p0, p1);
-    }
 };
 
 template <class PolylineLayoutVertex, class PolylineSegment>
@@ -74,7 +51,7 @@ public:
     using Vertices = gfx::VertexVector<PolylineLayoutVertex>;
     using Segments = std::vector<PolylineSegment>;
     using LayoutVertexFunc = std::function<PolylineLayoutVertex(
-        Point<int16_t> p, Point<double> e, bool round, bool up, int8_t dir, float linesofar /*= 0*/)>;
+        Point<int16_t> p, Point<double> e, bool round, bool up, int8_t dir, int32_t linesofar /*= 0*/)>;
     using CreateSegmentFunc = std::function<PolylineSegment(std::size_t vertexOffset, std::size_t indexOffset)>;
     using GetSegmentFunc = std::function<mbgl::SegmentBase&(PolylineSegment& segment)>;
     using Indexes = gfx::IndexVector<gfx::Triangles>;
@@ -96,24 +73,20 @@ private:
 
     void addCurrentVertex(const GeometryCoordinate& currentCoordinate,
                           double& distance,
-                          double& distanceInMeters,
                           const Point<double>& normal,
                           double endLeft,
                           double endRight,
                           bool round,
                           std::size_t startVertex,
                           std::vector<TriangleElement>& triangleStore,
-                          std::optional<PolylineGeneratorDistances> lineDistances,
-                          const PolylineGeneratorOptions& popts);
+                          std::optional<PolylineGeneratorDistances> lineDistances);
     void addPieSliceVertex(const GeometryCoordinate& currentVertex,
                            double distance,
-                           double distanceInMeters,
                            const Point<double>& extrude,
                            bool lineTurnsLeft,
                            std::size_t startVertex,
                            std::vector<TriangleElement>& triangleStore,
-                           std::optional<PolylineGeneratorDistances> lineDistances,
-                           const PolylineGeneratorOptions& popts);
+                           std::optional<PolylineGeneratorDistances> lineDistances);
 
 private:
     Vertices& vertices;
@@ -122,7 +95,6 @@ private:
     CreateSegmentFunc createSegment;
     GetSegmentFunc getSegment;
     Indexes& indexes;
-    const bool logVertices = true;
 
     std::ptrdiff_t e1;
     std::ptrdiff_t e2;

--- a/include/mbgl/route/route.hpp
+++ b/include/mbgl/route/route.hpp
@@ -83,6 +83,7 @@ private:
     std::vector<double> cumulativeIntervalDistances_;
     std::vector<RouteSegment> segments_;
     mbgl::LineString<double> geometry_;
+    mbgl::LineString<double> geometryMerc_;
     std::map<double, mbgl::Color> segGradient_;
     double totalLength_ = 0.0;
     std::vector<double> capturedNavPercent_;

--- a/include/mbgl/shaders/gl/drawable_line_gradient.hpp
+++ b/include/mbgl/shaders/gl/drawable_line_gradient.hpp
@@ -217,7 +217,7 @@ lowp float opacity = u_opacity;
     // scaled to [0, 2^15), and the gradient ramp is stored in a texture.
     vec4 color = texture(u_image, vec2(v_lineprogress, 0.5));
 
-    if(v_line_so_far <= v_line_clip) {
+    if(v_lineprogress <= v_line_clip) {
         color = v_clip_color;
     }
 

--- a/include/mbgl/shaders/gl/drawable_line_gradient.hpp
+++ b/include/mbgl/shaders/gl/drawable_line_gradient.hpp
@@ -22,7 +22,6 @@ struct ShaderSource<BuiltIn::LineGradientShader, gfx::Backend::Type::OpenGL> {
 
 layout (location = 0) in vec2 a_pos_normal;
 layout (location = 1) in vec4 a_data;
-layout (location = 2) in float a_line_so_far;
 
 layout (std140) uniform GlobalPaintParamsUBO {
     highp vec2 u_pattern_atlas_texsize;
@@ -68,7 +67,6 @@ out float v_gamma_scale;
 out highp float v_lineprogress;
 flat out highp float v_line_clip;
 flat out vec4 v_clip_color;
-out highp float v_line_so_far;
 
 #ifndef HAS_UNIFORM_u_blur
 layout (location = 2) in lowp vec2 a_blur;
@@ -123,7 +121,6 @@ mediump float width = u_width;
     float a_direction = mod(a_data.z, 4.0) - 1.0;
 
     v_lineprogress = (floor(a_data.z / 4.0) + a_data.w * 64.0) * 2.0 / MAX_LINE_DISTANCE;
-    v_line_so_far = a_line_so_far;
     vec2 pos = floor(a_pos_normal * 0.5);
 
     // x is 1 if it's a round cap, 0 otherwise
@@ -187,7 +184,6 @@ in float v_gamma_scale;
 in highp float v_lineprogress;
 flat in highp float v_line_clip;
 flat in vec4 v_clip_color;
-in highp float v_line_so_far;
 
 #ifndef HAS_UNIFORM_u_blur
 in lowp float blur;
@@ -220,10 +216,6 @@ lowp float opacity = u_opacity;
     if(v_lineprogress <= v_line_clip) {
         color = v_clip_color;
     }
-
-    //color = vec4(v_lineprogress, 0.0f, 0.0f, 1.0f);
-    //color = vec4(v_line_so_far, 0.0f, 0.0f, 1.0f);
-    //color.a = v_line_so_far;
 
     fragColor = color * (alpha * opacity);
 

--- a/platform/glfw/glfw_backend.hpp
+++ b/platform/glfw/glfw_backend.hpp
@@ -13,6 +13,7 @@ struct GLFWwindow;
 
 class GLFWBackend {
 public:
+    std::string assetPath;
     explicit GLFWBackend() = default;
     GLFWBackend(const GLFWBackend&) = delete;
     GLFWBackend& operator=(const GLFWBackend&) = delete;

--- a/platform/glfw/glfw_gl_backend.cpp
+++ b/platform/glfw/glfw_gl_backend.cpp
@@ -69,7 +69,9 @@ void GLFWGLBackend::enableCustomPuck(bool onOff) {
     customPuckState_.cameraTracking = false;
     customPuckState_.bearing = 0;
     if (onOff) {
-        customPuck->setPuckStyle("platform/glfw/assets/puck_style.json");
+        assert(!assetPath.empty() && "Asset path must be set before enabling custom puck.");
+        std::string puckStylePath = assetPath + "puck_style.json";
+        customPuck->setPuckStyle(puckStylePath);
         customPuck->setPuckVariant("default");
         customPuck->setPuckIconState("default");
     }

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -1494,15 +1494,14 @@ void GLFWView::readAndLoadCapture(const std::string &capture_file_name) {
         setPuckLocation(pt.y, pt.x, bearing);
 
         double totalRouteDistMeters = rmptr_->getTotalDistance(vanishingRouteID_);
-        bool useMercator = false;
-        if (useMercator) {
-            feet_percent_step_ = 0.000000076;
+        if (routeProgressPrecision_ == mbgl::route::Precision::Mercator) {
+            feet_percent_step_ = 0.000000076 * 20; // 20 is a speed multiplier, 7.6e-8 is one feet on equator
         } else {
             double totalRouteDistFeet = totalRouteDistMeters * 3.28084; // Convert meters to feet
             feet_percent_step_ = 1.0 / totalRouteDistFeet;
         }
 
-        std::cout << "feet_step_percent: " << std::to_string(feet_percent_step_) << std::endl;
+        std::cout << "feet_step_percent: " << feet_percent_step_ << std::endl;
     }
 }
 

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -354,6 +354,7 @@ GLFWView::GLFWView(bool fullscreen_,
 
     bool capFrameRate = !benchmark; // disable VSync in benchmark mode
     backend = GLFWBackend::Create(window, capFrameRate);
+    backend->assetPath = MLN_ASSETS_PATH;
 
 #if defined(__APPLE__) && !defined(MLN_RENDER_BACKEND_VULKAN)
     int fbW, fbH;
@@ -1065,7 +1066,7 @@ void GLFWView::addRoute() {
     routeOpts.useDynamicWidths = false;
     routeOpts.outerClipColor = mbgl::Color(0.5, 0.5, 0.5, 1.0);
     routeOpts.innerClipColor = mbgl::Color(0.5, 0.5, 0.5, 1.0);
-    routeOpts.useMercatorProjection = true;
+    routeOpts.useMercatorProjection = false;
 
     auto routeID = rmptr_->routeCreate(geom, routeOpts);
     routeMap_[routeID] = route;
@@ -1493,7 +1494,7 @@ void GLFWView::readAndLoadCapture(const std::string &capture_file_name) {
         setPuckLocation(pt.y, pt.x, bearing);
 
         double totalRouteDistMeters = rmptr_->getTotalDistance(vanishingRouteID_);
-        bool useMercator = true;
+        bool useMercator = false;
         if (useMercator) {
             feet_percent_step_ = 0.000000076;
         } else {

--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -203,13 +203,12 @@ private:
     std::unordered_map<RouteID, RouteData, IDHasher<RouteID>> routeMap_;
     std::unordered_map<RouteID, mbgl::LineString<double>, IDHasher<RouteID>> capturedNavStopMap_;
     std::unordered_map<RouteID, std::vector<double>, IDHasher<RouteID>> capturedNavPercentMap_;
-    mbgl::route::Precision routeProgressPrecision_ = mbgl::route::Precision::Fine;
+    mbgl::route::Precision routeProgressPrecision_ = mbgl::route::Precision::Mercator;
     RouteID vanishingRouteID_;
     bool loadedCapture_ = false;
     double routeProgress_ = 0.0;
     bool routePickMode_ = false;
     bool enableAutoVanishing = false; // Simulates route progress in app
-    mbgl::route::Precision routePrecision_ = mbgl::route::Precision::Fine;
     int scrubCounter_ = 0;
     bool enableDebugViz_ = true;
     double testPercent_ = 0.0; // Used for testing route progress

--- a/src/mbgl/gfx/polyline_generator.cpp
+++ b/src/mbgl/gfx/polyline_generator.cpp
@@ -10,7 +10,6 @@
 #include <mbgl/gfx/drawable_impl.hpp>
 #endif
 
-#include <iostream>
 #include <memory>
 #include <numbers>
 
@@ -57,28 +56,6 @@ double PolylineGeneratorDistances::scaleToMaxLineDistance(double tileDistance) c
         relativeTileDistance = 0.0;
     }
     return (relativeTileDistance * (clipEnd - clipStart) + clipStart) * (MAX_LINE_DISTANCE - 1);
-}
-
-double PolylineGeneratorDistances::unscaledDistance(double tileDistance) const {
-    double relativeTileDistance = tileDistance / total;
-    if (std::isinf(relativeTileDistance) || std::isnan(relativeTileDistance)) {
-        assert(false);
-        relativeTileDistance = 0.0;
-    }
-
-    double unscaled = (relativeTileDistance * (clipEnd - clipStart) + clipStart);
-    return unscaled;
-}
-
-double PolylineGeneratorDistances::routeDistance(double routeDistanceSoFar, double totalRouteDistance) const {
-    double relativeTileDistance = routeDistanceSoFar / totalRouteDistance;
-    if (std::isinf(relativeTileDistance) || std::isnan(relativeTileDistance)) {
-        assert(false);
-        relativeTileDistance = 0.0;
-    }
-
-    double routeDist = (relativeTileDistance * (clipEnd - clipStart) + clipStart);
-    return routeDist;
 }
 
 template <class PLV, class PS>
@@ -146,7 +123,6 @@ void PolylineGenerator<PLV, PS>::generate(const GeometryCoordinates& coordinates
     const style::LineCapType endCap = options.type == FeatureType::Polygon ? style::LineCapType::Butt : options.endCap;
 
     double distance = 0.0;
-    double distanceInMeters = 0.0;
     bool startOfLine = true;
     std::optional<GeometryCoordinate> currentCoordinate;
     std::optional<GeometryCoordinate> prevCoordinate;
@@ -256,18 +232,15 @@ void PolylineGenerator<PLV, PS>::generate(const GeometryCoordinates& coordinates
                                                        convertPoint<double>(*currentCoordinate - *prevCoordinate) *
                                                        (sharpCornerOffset / prevSegmentLength)));
                 distance += util::dist<double>(newPrevVertex, *prevCoordinate);
-                distanceInMeters += options.haversineDist(newPrevVertex, *prevCoordinate);
                 addCurrentVertex(newPrevVertex,
                                  distance,
-                                 distanceInMeters,
                                  *prevNormal,
                                  0,
                                  0,
                                  false,
                                  startVertex,
                                  triangleStore,
-                                 options.clipDistances,
-                                 options);
+                                 options.clipDistances);
                 prevCoordinate = newPrevVertex;
             }
         }
@@ -309,7 +282,6 @@ void PolylineGenerator<PLV, PS>::generate(const GeometryCoordinates& coordinates
         // Calculate how far along the line the currentVertex is
         if (prevCoordinate) {
             distance += util::dist<double>(*currentCoordinate, *prevCoordinate);
-            distanceInMeters += options.haversineDist(*currentCoordinate, *prevCoordinate);
         }
 
         if (middleVertex && currentJoin == style::LineJoinType::Miter) {
@@ -317,15 +289,13 @@ void PolylineGenerator<PLV, PS>::generate(const GeometryCoordinates& coordinates
 
             addCurrentVertex(*currentCoordinate,
                              distance,
-                             distanceInMeters,
                              joinNormal,
                              0,
                              0,
                              false,
                              startVertex,
                              triangleStore,
-                             options.clipDistances,
-                             options);
+                             options.clipDistances);
 
         } else if (middleVertex && currentJoin == style::LineJoinType::FlipBevel) {
             // miter is too big, flip the direction to make a beveled join
@@ -342,27 +312,23 @@ void PolylineGenerator<PLV, PS>::generate(const GeometryCoordinates& coordinates
 
             addCurrentVertex(*currentCoordinate,
                              distance,
-                             distanceInMeters,
                              joinNormal,
                              0,
                              0,
                              false,
                              startVertex,
                              triangleStore,
-                             options.clipDistances,
-                             options);
+                             options.clipDistances);
 
             addCurrentVertex(*currentCoordinate,
                              distance,
-                             distanceInMeters,
                              joinNormal * -1.0,
                              0,
                              0,
                              false,
                              startVertex,
                              triangleStore,
-                             options.clipDistances,
-                             options);
+                             options.clipDistances);
         } else if (middleVertex &&
                    (currentJoin == style::LineJoinType::Bevel || currentJoin == style::LineJoinType::FakeRound)) {
             const bool lineTurnsLeft = (prevNormal->x * nextNormal->y - prevNormal->y * nextNormal->x) > 0;
@@ -382,15 +348,13 @@ void PolylineGenerator<PLV, PS>::generate(const GeometryCoordinates& coordinates
             if (!startOfLine) {
                 addCurrentVertex(*currentCoordinate,
                                  distance,
-                                 distanceInMeters,
                                  *prevNormal,
                                  offsetA,
                                  offsetB,
                                  false,
                                  startVertex,
                                  triangleStore,
-                                 options.clipDistances,
-                                 options);
+                                 options.clipDistances);
             }
 
             if (currentJoin == style::LineJoinType::FakeRound) {
@@ -417,13 +381,11 @@ void PolylineGenerator<PLV, PS>::generate(const GeometryCoordinates& coordinates
                     auto approxFractionalNormal = util::unit(*prevNormal * (1.0 - t) + *nextNormal * t);
                     addPieSliceVertex(*currentCoordinate,
                                       distance,
-                                      distanceInMeters,
                                       approxFractionalNormal,
                                       lineTurnsLeft,
                                       startVertex,
                                       triangleStore,
-                                      options.clipDistances,
-                                      options);
+                                      options.clipDistances);
                 }
             }
 
@@ -431,15 +393,13 @@ void PolylineGenerator<PLV, PS>::generate(const GeometryCoordinates& coordinates
             if (nextCoordinate) {
                 addCurrentVertex(*currentCoordinate,
                                  distance,
-                                 distanceInMeters,
                                  *nextNormal,
                                  -offsetA,
                                  -offsetB,
                                  false,
                                  startVertex,
                                  triangleStore,
-                                 options.clipDistances,
-                                 options);
+                                 options.clipDistances);
             }
 
         } else if (!middleVertex && currentCap == style::LineCapType::Butt) {
@@ -447,30 +407,26 @@ void PolylineGenerator<PLV, PS>::generate(const GeometryCoordinates& coordinates
                 // Close previous segment with a butt
                 addCurrentVertex(*currentCoordinate,
                                  distance,
-                                 distanceInMeters,
                                  *prevNormal,
                                  0,
                                  0,
                                  false,
                                  startVertex,
                                  triangleStore,
-                                 options.clipDistances,
-                                 options);
+                                 options.clipDistances);
             }
 
             // Start next segment with a butt
             if (nextCoordinate) {
                 addCurrentVertex(*currentCoordinate,
                                  distance,
-                                 distanceInMeters,
                                  *nextNormal,
                                  0,
                                  0,
                                  false,
                                  startVertex,
                                  triangleStore,
-                                 options.clipDistances,
-                                 options);
+                                 options.clipDistances);
             }
 
         } else if (!middleVertex && currentCap == style::LineCapType::Square) {
@@ -478,15 +434,13 @@ void PolylineGenerator<PLV, PS>::generate(const GeometryCoordinates& coordinates
                 // Close previous segment with a square cap
                 addCurrentVertex(*currentCoordinate,
                                  distance,
-                                 distanceInMeters,
                                  *prevNormal,
                                  1,
                                  1,
                                  false,
                                  startVertex,
                                  triangleStore,
-                                 options.clipDistances,
-                                 options);
+                                 options.clipDistances);
 
                 // The segment is done. Unset vertices to disconnect segments.
                 e1 = e2 = -1;
@@ -496,15 +450,13 @@ void PolylineGenerator<PLV, PS>::generate(const GeometryCoordinates& coordinates
             if (nextCoordinate) {
                 addCurrentVertex(*currentCoordinate,
                                  distance,
-                                 distanceInMeters,
                                  *nextNormal,
                                  -1,
                                  -1,
                                  false,
                                  startVertex,
                                  triangleStore,
-                                 options.clipDistances,
-                                 options);
+                                 options.clipDistances);
             }
 
         } else if (middleVertex ? currentJoin == style::LineJoinType::Round : currentCap == style::LineCapType::Round) {
@@ -512,28 +464,24 @@ void PolylineGenerator<PLV, PS>::generate(const GeometryCoordinates& coordinates
                 // Close previous segment with a butt
                 addCurrentVertex(*currentCoordinate,
                                  distance,
-                                 distanceInMeters,
                                  *prevNormal,
                                  0,
                                  0,
                                  false,
                                  startVertex,
                                  triangleStore,
-                                 options.clipDistances,
-                                 options);
+                                 options.clipDistances);
 
                 // Add round cap or linejoin at end of segment
                 addCurrentVertex(*currentCoordinate,
                                  distance,
-                                 distanceInMeters,
                                  *prevNormal,
                                  1,
                                  1,
                                  true,
                                  startVertex,
                                  triangleStore,
-                                 options.clipDistances,
-                                 options);
+                                 options.clipDistances);
 
                 // The segment is done. Unset vertices to disconnect segments.
                 e1 = e2 = -1;
@@ -544,27 +492,23 @@ void PolylineGenerator<PLV, PS>::generate(const GeometryCoordinates& coordinates
                 // Add round cap before first segment
                 addCurrentVertex(*currentCoordinate,
                                  distance,
-                                 distanceInMeters,
                                  *nextNormal,
                                  -1,
                                  -1,
                                  true,
                                  startVertex,
                                  triangleStore,
-                                 options.clipDistances,
-                                 options);
+                                 options.clipDistances);
 
                 addCurrentVertex(*currentCoordinate,
                                  distance,
-                                 distanceInMeters,
                                  *nextNormal,
                                  0,
                                  0,
                                  false,
                                  startVertex,
                                  triangleStore,
-                                 options.clipDistances,
-                                 options);
+                                 options.clipDistances);
             }
         }
 
@@ -576,18 +520,15 @@ void PolylineGenerator<PLV, PS>::generate(const GeometryCoordinates& coordinates
                                                           convertPoint<double>(*nextCoordinate - *currentCoordinate) *
                                                           (sharpCornerOffset / nextSegmentLength)));
                 distance += util::dist<double>(newCurrentVertex, *currentCoordinate);
-                distanceInMeters += options.haversineDist(newCurrentVertex, *currentCoordinate);
                 addCurrentVertex(newCurrentVertex,
                                  distance,
-                                 distanceInMeters,
                                  *nextNormal,
                                  0,
                                  0,
                                  false,
                                  startVertex,
                                  triangleStore,
-                                 options.clipDistances,
-                                 options);
+                                 options.clipDistances);
                 currentCoordinate = newCurrentVertex;
             }
         }
@@ -622,48 +563,25 @@ void PolylineGenerator<PLV, PS>::generate(const GeometryCoordinates& coordinates
 template <class PLV, class PS>
 void PolylineGenerator<PLV, PS>::addCurrentVertex(const GeometryCoordinate& currentCoordinate,
                                                   double& distance,
-                                                  [[maybe_unused]] double& distanceInMeters,
                                                   const Point<double>& normal,
                                                   double endLeft,
                                                   double endRight,
                                                   bool round,
                                                   std::size_t startVertex,
                                                   std::vector<TriangleElement>& triangleStore,
-                                                  std::optional<PolylineGeneratorDistances> lineDistances,
-                                                  const PolylineGeneratorOptions& popts) {
+                                                  std::optional<PolylineGeneratorDistances> lineDistances) {
     Point<double> extrude = normal;
     const double scaledDistance = lineDistances ? lineDistances->scaleToMaxLineDistance(distance) : distance;
-    double unscaledDistance = lineDistances ? lineDistances->unscaledDistance(distance) : -1.0;
-    float unscaledDistanceF = static_cast<float>(unscaledDistance);
 
     if (endLeft) extrude = extrude - (util::perp(normal) * endLeft);
-    double clipstart = lineDistances ? lineDistances->clipStart : 0.0;
-    double clipend = lineDistances ? lineDistances->clipEnd : 0.0;
-    double scaledVertexAttrib = scaledDistance * LINE_DISTANCE_SCALE;
-    double scaledInVertexShader = scaledVertexAttrib * (2.0 / (MAX_LINE_DISTANCE - 1));
-    double haversineVertexAttrib = popts.isRoutePath
-                                       ? lineDistances->routeDistance(distanceInMeters, popts.totalInMeters)
-                                       : 0.0;
-
-    std::string routeMode = popts.isRoutePath ? "route mode ON" : "route mode OFF";
-    // float lineSoFar = popts.isRoutePath ? haversineVertexAttrib : scaledDistance * LINE_DISTANCE_SCALE;
-    float lineSoFar = popts.isRoutePath ? scaledDistance * LINE_DISTANCE_SCALE : scaledDistance * LINE_DISTANCE_SCALE;
-
-    if (popts.isRoutePath && logVertices) {
-        std::stringstream ss;
-        ss.setf(std::ios::fixed);
-        ss.precision(15);
-        ss << "add vertex: scaledDistance: " << scaledDistance << ", unscaledDistance: " << unscaledDistanceF << ", "
-           << routeMode << ", tileID: " << std::to_string(popts.canonicalTileID.z) << " " << popts.canonicalTileID.x
-           << " " << popts.canonicalTileID.y << " {clipstart: " << clipstart << ", clipend: " << clipend
-           << ", lineSoFar - haversine: " << haversineVertexAttrib << ", scaledInVertex: " << scaledInVertexShader
-           << ", unscaledInVertex: " << unscaledDistanceF << "}" << std::endl;
-        mbgl::Log::Info(Event::Route, ss.str());
-    }
 
     // distance is distance so far.
-    vertices.emplace_back(
-        layoutVertex(currentCoordinate, extrude, round, false, static_cast<int8_t>(endLeft), lineSoFar));
+    vertices.emplace_back(layoutVertex(currentCoordinate,
+                                       extrude,
+                                       round,
+                                       false,
+                                       static_cast<int8_t>(endLeft),
+                                       static_cast<int32_t>(scaledDistance * LINE_DISTANCE_SCALE)));
 
     e3 = vertices.elements() - 1 - startVertex;
     if (e1 >= 0 && e2 >= 0) {
@@ -674,8 +592,12 @@ void PolylineGenerator<PLV, PS>::addCurrentVertex(const GeometryCoordinate& curr
 
     extrude = normal * -1.0;
     if (endRight) extrude = extrude - (util::perp(normal) * endRight);
-    vertices.emplace_back(
-        layoutVertex(currentCoordinate, extrude, round, true, static_cast<int8_t>(-endRight), lineSoFar));
+    vertices.emplace_back(layoutVertex(currentCoordinate,
+                                       extrude,
+                                       round,
+                                       true,
+                                       static_cast<int8_t>(-endRight),
+                                       static_cast<int32_t>(scaledDistance * LINE_DISTANCE_SCALE)));
     e3 = vertices.elements() - 1 - startVertex;
     if (e1 >= 0 && e2 >= 0) {
         triangleStore.emplace_back(static_cast<uint16_t>(e1), static_cast<uint16_t>(e2), static_cast<uint16_t>(e3));
@@ -687,47 +609,29 @@ void PolylineGenerator<PLV, PS>::addCurrentVertex(const GeometryCoordinate& curr
     // buffers. When we get close to the distance, reset it to zero and add the
     // vertex again with a distance of zero. The max distance is determined by
     // the number of bits we allocate to `linesofar`.
-    if (distance > MAX_LINE_DISTANCE / 2.0f && !lineDistances && !popts.isRoutePath) {
+    if (distance > MAX_LINE_DISTANCE / 2.0f && !lineDistances) {
         distance = 0.0;
-        distanceInMeters = 0.0;
-        addCurrentVertex(currentCoordinate,
-                         distance,
-                         distanceInMeters,
-                         normal,
-                         endLeft,
-                         endRight,
-                         round,
-                         startVertex,
-                         triangleStore,
-                         lineDistances,
-                         popts);
+        addCurrentVertex(
+            currentCoordinate, distance, normal, endLeft, endRight, round, startVertex, triangleStore, lineDistances);
     }
 }
 
 template <class PLV, class PS>
 void PolylineGenerator<PLV, PS>::addPieSliceVertex(const GeometryCoordinate& currentVertex,
                                                    double distance,
-                                                   [[maybe_unused]] double distanceInMeters,
                                                    const Point<double>& extrude,
                                                    bool lineTurnsLeft,
                                                    std::size_t startVertex,
                                                    std::vector<TriangleElement>& triangleStore,
-                                                   std::optional<PolylineGeneratorDistances> lineDistances,
-                                                   const PolylineGeneratorOptions& popts) {
+                                                   std::optional<PolylineGeneratorDistances> lineDistances) {
     Point<double> flippedExtrude = extrude * (lineTurnsLeft ? -1.0 : 1.0);
 
     if (lineDistances) {
         distance = lineDistances->scaleToMaxLineDistance(distance);
     }
 
-    // double unscaledDistance = lineDistances ? lineDistances->unscaledDistance(distance) : distance/32767.0;
-    // float unscaledDistanceF = static_cast<float>(unscaledDistance);
-    // double vertexAttribLineSoFar = popts.isRoutePath
-    //                                    ? lineDistances->routeDistance(distanceInMeters, popts.totalInMeters)
-    //                                    : 0.0;
-    // float lineSoFar = popts.isRoutePath ? vertexAttribLineSoFar : distance * LINE_DISTANCE_SCALE;
-    float lineSoFar = popts.isRoutePath ? distance * LINE_DISTANCE_SCALE : distance * LINE_DISTANCE_SCALE;
-    vertices.emplace_back(layoutVertex(currentVertex, flippedExtrude, false, lineTurnsLeft, 0, lineSoFar));
+    vertices.emplace_back(layoutVertex(
+        currentVertex, flippedExtrude, false, lineTurnsLeft, 0, static_cast<int32_t>(distance * LINE_DISTANCE_SCALE)));
     e3 = vertices.elements() - 1 - startVertex;
     if (e1 >= 0 && e2 >= 0) {
         triangleStore.emplace_back(static_cast<uint16_t>(e1), static_cast<uint16_t>(e2), static_cast<uint16_t>(e3));

--- a/src/mbgl/gl/custom_puck.cpp
+++ b/src/mbgl/gl/custom_puck.cpp
@@ -167,8 +167,9 @@ void CustomPuck::updateTextures(const gfx::CustomPuckIconMap& icons) {
     context.renderingStats().memTextures -= storage;
     storage = 0;
     for (auto& [name, tex] : textures) {
+        GLuint texID = tex;
         if (tex) {
-            MBGL_CHECK_ERROR(glDeleteTextures(1, &tex));
+            MBGL_CHECK_ERROR(glDeleteTextures(1, &texID));
             MLN_TRACE_FREE_TEXTURE(tex);
         }
     }
@@ -177,7 +178,7 @@ void CustomPuck::updateTextures(const gfx::CustomPuckIconMap& icons) {
     // Create new textures
     for (const auto& [name, path] : icons) {
         TextureID tex = 0;
-        auto image = mbgl::decodeImage(readFile(path));
+        auto image = mbgl::decodeImage(readFile("../../../" + path));
         if (!image.valid()) {
             Log::Error(Event::OpenGL, "Failed to load puck icon " + path);
             throw std::runtime_error("Failed to load puck icon " + path);

--- a/src/mbgl/layout/pattern_layout.hpp
+++ b/src/mbgl/layout/pattern_layout.hpp
@@ -179,9 +179,6 @@ public:
                       const bool /*showCollisionBoxes*/,
                       const CanonicalTileID& canonical) override {
         auto bucket = std::make_shared<BucketType>(layout, layerPropertiesMap, zoom, overscaling);
-        if (bucketLeaderID.find("route_layer") != std::string::npos) {
-            bucket->setRouteBucket(true);
-        }
         for (auto& patternFeature : features) {
             const auto i = patternFeature.i;
             std::unique_ptr<GeometryTileFeature> feature = std::move(patternFeature.feature);

--- a/src/mbgl/programs/attributes.hpp
+++ b/src/mbgl/programs/attributes.hpp
@@ -11,7 +11,6 @@ MBGL_DEFINE_ATTRIBUTE(int16_t, 2, pos);
 MBGL_DEFINE_ATTRIBUTE(int16_t, 2, extrude);
 MBGL_DEFINE_ATTRIBUTE(int16_t, 4, pos_offset);
 MBGL_DEFINE_ATTRIBUTE(int16_t, 2, pos_normal);
-MBGL_DEFINE_ATTRIBUTE(float, 1, line_so_far);
 MBGL_DEFINE_ATTRIBUTE(float, 3, projected_pos);
 MBGL_DEFINE_ATTRIBUTE(int16_t, 4, pixeloffset);
 MBGL_DEFINE_ATTRIBUTE(int16_t, 2, label_pos);

--- a/src/mbgl/programs/line_program.cpp
+++ b/src/mbgl/programs/line_program.cpp
@@ -10,7 +10,7 @@ namespace mbgl {
 
 using namespace style;
 
-static_assert(sizeof(LineLayoutVertex) == 12, "expected LineLayoutVertex size");
+static_assert(sizeof(LineLayoutVertex) == 8, "expected LineLayoutVertex size");
 
 template <class Values, class... Args>
 Values makeValues(const style::LinePaintProperties::PossiblyEvaluated& properties,

--- a/src/mbgl/programs/line_program.hpp
+++ b/src/mbgl/programs/line_program.hpp
@@ -27,7 +27,7 @@ MBGL_DEFINE_UNIFORM_VECTOR(float, 2, patternscale_b);
 MBGL_DEFINE_UNIFORM_VECTOR(float, 2, units_to_pixels);
 } // namespace uniforms
 
-using LineLayoutAttributes = TypeList<attributes::pos_normal, attributes::data<uint8_t, 4>, attributes::line_so_far>;
+using LineLayoutAttributes = TypeList<attributes::pos_normal, attributes::data<uint8_t, 4>>;
 
 class LineProgram final
     : public Program<
@@ -52,8 +52,7 @@ public:
      * @param dir direction of the line cap (-1/0/1)
      */
     static LayoutVertex layoutVertex(
-        Point<int16_t> p, Point<double> e, bool round, bool up, int8_t dir, float linesofar) {
-        int32_t linesofarI = static_cast<int32_t>(linesofar);
+        Point<int16_t> p, Point<double> e, bool round, bool up, int8_t dir, int32_t linesofar) {
         return LayoutVertex{
             {{static_cast<int16_t>((p.x * 2) | (round ? 1 : 0)), static_cast<int16_t>((p.y * 2) | (up ? 1 : 0))}},
             {{// add 128 to store a byte in an unsigned byte
@@ -72,9 +71,8 @@ public:
               // merge them. The z component's first bit, as well as the sign
               // bit is reserved for the direction, so we need to shift the
               // linesofar.
-              static_cast<uint8_t>(((dir == 0 ? 0 : (dir < 0 ? -1 : 1)) + 1) | ((linesofarI & 0x3F) << 2)),
-              static_cast<uint8_t>(linesofarI >> 6)}},
-            {linesofar}};
+              static_cast<uint8_t>(((dir == 0 ? 0 : (dir < 0 ? -1 : 1)) + 1) | ((linesofar & 0x3F) << 2)),
+              static_cast<uint8_t>(linesofar >> 6)}}};
     }
 
     /*

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -54,8 +54,6 @@ public:
 
     virtual bool hasData() const = 0;
 
-    virtual void setRouteBucket([[maybe_unused]] bool isBucketForRoute) {}
-
     virtual float getQueryRadius(const RenderLayer&) const { return 0; };
 
     bool needsUpload() const { return hasData() && !uploaded; }

--- a/src/mbgl/renderer/buckets/line_bucket.cpp
+++ b/src/mbgl/renderer/buckets/line_bucket.cpp
@@ -52,17 +52,9 @@ void LineBucket::addFeature(const GeometryTileFeature& feature,
     }
 }
 
-#ifdef DEBUG_SINGLE_THREAD
-std::mutex g_debug_mutex;
-#endif
-
 void LineBucket::addGeometry(const GeometryCoordinates& coordinates,
                              const GeometryTileFeature& feature,
                              const CanonicalTileID& canonical) {
-#ifdef DEBUG_SINGLE_THREAD
-    std::lock_guard<std::mutex> lock(g_debug_mutex);
-#endif
-
     gfx::PolylineGeneratorOptions options;
 
     options.type = feature.getType();

--- a/src/mbgl/renderer/buckets/line_bucket.cpp
+++ b/src/mbgl/renderer/buckets/line_bucket.cpp
@@ -6,7 +6,6 @@
 #include <mbgl/gfx/polyline_generator.hpp>
 
 #include <cassert>
-#include <iostream>
 #include <utility>
 
 namespace mbgl {
@@ -104,19 +103,6 @@ void LineBucket::addGeometry(const GeometryCoordinates& coordinates,
 
         options.clipDistances = gfx::PolylineGeneratorDistances{
             *numericValue<double>(clip_start_it->second), *numericValue<double>(clip_end_it->second), total_length};
-    }
-
-    options.isRoutePath = isRouteBucket;
-    options.canonicalTileID = canonical;
-    if (isRouteBucket) {
-        double total_length_in_meters = 0.0;
-        for (std::size_t i = first; i < len - 1; ++i) {
-            Point<double> p0 = options.tileCoordinatesToLatLng(coordinates[i]);
-            Point<double> p1 = options.tileCoordinatesToLatLng(coordinates[i + 1]);
-
-            total_length_in_meters += util::haversineDist(p0, p1);
-        }
-        options.totalInMeters = total_length_in_meters;
     }
 
     options.joinType = layout.evaluate<LineJoin>(zoom, feature, canonical);

--- a/src/mbgl/renderer/buckets/line_bucket.hpp
+++ b/src/mbgl/renderer/buckets/line_bucket.hpp
@@ -32,8 +32,6 @@ public:
                     std::size_t,
                     const CanonicalTileID&) override;
 
-    void setRouteBucket(bool isBucketForRoute) override { isRouteBucket = isBucketForRoute; }
-
     bool hasData() const override;
 
     void upload(gfx::UploadPass&) override;
@@ -66,7 +64,6 @@ private:
 
     const float zoom;
     const uint32_t overscaling;
-    bool isRouteBucket = false;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -449,14 +449,6 @@ void RenderLineLayer::update(gfx::ShaderRegistry& shaders,
                                        gfx::AttributeDataType::UByte4);
             }
 
-            if (const auto& attr = vertexAttrs->set(idLineLineSofarAttribute)) {
-                attr->setSharedRawData(bucket.sharedVertices,
-                                       offsetof(LineLayoutVertex, a3),
-                                       /*vertexOffset=*/0,
-                                       sizeof(LineLayoutVertex),
-                                       gfx::AttributeDataType::Float);
-            }
-
             builder.setVertexAttributes(std::move(vertexAttrs));
         };
 

--- a/src/mbgl/route/route.cpp
+++ b/src/mbgl/route/route.cpp
@@ -636,10 +636,9 @@ void Route::addNavStopPoint(const mbgl::Point<double>& point) {
 
 double Route::getProgressPercent(const Point<double>& progressPoint, const Precision& precision, bool capture) {
     double percentage = -1.0;
-    // TODO: refactor to a better such that we can co
+    // TODO: refactor such that we have a coherent way of setting usage of mercator projection
     if (routeOptions_.useMercatorProjection || precision == Precision::Mercator) {
         percentage = getProgressProjectionMerc(progressPoint, capture);
-        std::cout << "merc percentage: " << percentage << std::endl;
     } else {
         switch (precision) {
             case Precision::Coarse: {

--- a/src/mbgl/route/route_manager.cpp
+++ b/src/mbgl/route/route_manager.cpp
@@ -576,7 +576,7 @@ bool RouteManager::loadCapture(const std::string& capture) {
                     }
 
                     // TODO: add this to route capture
-                    routeOpts.useMercatorProjection = true;
+                    // routeOpts.useMercatorProjection = true;
                 }
 
                 mbgl::LineString<double> route_geom;
@@ -745,8 +745,8 @@ bool RouteManager::captureScrubRoute(double scrubValue,
             double bearing = 0.0;
             const auto& navstop = getPoint(vanishingRouteID_, scrubValue, Precision::Fine, &bearing);
             if (scrubOpts.fallbackPoint) {
-                std::cout << "merc mode- nav point: " << navstop.x << " " << navstop.y << std::endl;
-                routeSetProgressPoint(vanishingRouteID_, navstop, Precision::Mercator);
+                std::cout << "nav point: " << navstop.x << " " << navstop.y << std::endl;
+                routeSetProgressPoint(vanishingRouteID_, navstop, Precision::Fine);
             } else {
                 routeSetProgressPercent(vanishingRouteID_, scrubValue);
             }
@@ -877,6 +877,7 @@ double RouteManager::routeSetProgressPoint(const RouteID& routeID,
         {
             if (routeID.isValid() && routeMap_.find(routeID) != routeMap_.end()) {
                 percentage = routeMap_.at(routeID).getProgressPercent(progressPoint, precision, captureNavStops_);
+                std::cout << "Percentage: " << percentage << std::endl;
             }
         }
         auto endTime = std::chrono::high_resolution_clock::now();

--- a/src/mbgl/route/route_manager.cpp
+++ b/src/mbgl/route/route_manager.cpp
@@ -576,7 +576,7 @@ bool RouteManager::loadCapture(const std::string& capture) {
                     }
 
                     // TODO: add this to route capture
-                    // routeOpts.useMercatorProjection = true;
+                    routeOpts.useMercatorProjection = true;
                 }
 
                 mbgl::LineString<double> route_geom;
@@ -745,7 +745,6 @@ bool RouteManager::captureScrubRoute(double scrubValue,
             double bearing = 0.0;
             const auto& navstop = getPoint(vanishingRouteID_, scrubValue, Precision::Fine, &bearing);
             if (scrubOpts.fallbackPoint) {
-                std::cout << "nav point: " << navstop.x << " " << navstop.y << std::endl;
                 routeSetProgressPoint(vanishingRouteID_, navstop, Precision::Fine);
             } else {
                 routeSetProgressPercent(vanishingRouteID_, scrubValue);

--- a/src/mbgl/route/route_manager.cpp
+++ b/src/mbgl/route/route_manager.cpp
@@ -876,7 +876,6 @@ double RouteManager::routeSetProgressPoint(const RouteID& routeID,
         {
             if (routeID.isValid() && routeMap_.find(routeID) != routeMap_.end()) {
                 percentage = routeMap_.at(routeID).getProgressPercent(progressPoint, precision, captureNavStops_);
-                std::cout << "Percentage: " << percentage << std::endl;
             }
         }
         auto endTime = std::chrono::high_resolution_clock::now();

--- a/src/mbgl/shaders/gl/shader_info.cpp
+++ b/src/mbgl/shaders/gl/shader_info.cpp
@@ -371,7 +371,6 @@ const std::vector<UniformBlockInfo> LineGradientShaderInfo::uniformBlocks = {
 const std::vector<AttributeInfo> LineGradientShaderInfo::attributes = {
     AttributeInfo{"a_pos_normal", idLinePosNormalVertexAttribute},
     AttributeInfo{"a_data", idLineDataVertexAttribute},
-    AttributeInfo{"a_line_so_far", idLineLineSofarAttribute},
     AttributeInfo{"a_blur", idLineBlurVertexAttribute},
     AttributeInfo{"a_opacity", idLineOpacityVertexAttribute},
     AttributeInfo{"a_gapwidth", idLineGapWidthVertexAttribute},


### PR DESCRIPTION
This PR adds:

* support for web mercator projection test case in glfwview
* removal of all of the code changes made to support high precision line so far vertex attribute as it was identified that it did little to improve the vanishing gap issue and instead caused problems for traffic visualization