### PR TITLE
Fix non-looping puck animations

### DIFF
--- a/src/mbgl/gfx/custom_puck.cpp
+++ b/src/mbgl/gfx/custom_puck.cpp
@@ -128,6 +128,7 @@ void CustomPuck::setPuckVariant(std::string variant) {
 void CustomPuck::setPuckIconState(std::string state) {
     std::lock_guard<std::mutex> lock(styleMutex);
     iconStateName = std::move(state);
+    epochTime = std::chrono::steady_clock::now();
 }
 
 #ifdef __ANDROID__


### PR DESCRIPTION
Puck looping animations are working fine but for animations that run once the epoch time of the animation needs to be set.
This PR adds a small change to initialize the the epoch time when a puck state is set