### PR TITLE
Disable Location geojson refreshes when custom puck is used

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/IndicatorLocationLayerRenderer.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/IndicatorLocationLayerRenderer.java
@@ -206,6 +206,11 @@ class IndicatorLocationLayerRenderer implements LocationLayerRenderer {
     // not supported at this time
   }
 
+  @Override
+  public void disableLayers() {
+    // not supported at this time
+  }
+
   private void setImages(@RenderMode.Mode int renderMode, boolean isStale) {
     String topImage = "";
     String bearingImage = "";

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationComponent.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationComponent.java
@@ -274,6 +274,10 @@ public final class LocationComponent {
     initialize(activationOptions.context(), activationOptions.style(),
       activationOptions.useSpecializedLocationLayer(), options);
 
+    if (customPuckAnimationOptions.customPuckAnimationEnabled) {
+      locationLayerController.disableLayers();
+    }
+
     // Apply the LocationComponent styling
     // TODO avoid doubling style initialization
     applyStyle(options);

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationLayerController.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationLayerController.java
@@ -90,6 +90,10 @@ final class LocationLayerController {
     }
   }
 
+  public void disableLayers() {
+    locationLayerRenderer.disableLayers();
+  }
+
   void applyStyle(@NonNull LocationComponentOptions options) {
     if (positionManager.update(options.layerAbove(), options.layerBelow())) {
       locationLayerRenderer.removeLayers();

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationLayerRenderer.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationLayerRenderer.java
@@ -50,4 +50,6 @@ interface LocationLayerRenderer {
   void addBitmaps(@RenderMode.Mode int renderMode, @Nullable Bitmap shadowBitmap, Bitmap backgroundBitmap,
                   Bitmap backgroundStaleBitmap, Bitmap bearingBitmap,
                   Bitmap foregroundBitmap, Bitmap foregroundStaleBitmap);
+
+  void disableLayers();
 }

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/SymbolLocationLayerRenderer.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/SymbolLocationLayerRenderer.java
@@ -66,6 +66,7 @@ final class SymbolLocationLayerRenderer implements LocationLayerRenderer {
   private final Set<String> layerSet;
   private Feature locationFeature;
   private GeoJsonSource locationSource;
+  private boolean isDisabled = false;
 
   SymbolLocationLayerRenderer(LayerSourceProvider layerSourceProvider,
                               LayerFeatureProvider featureProvider,
@@ -323,6 +324,10 @@ final class SymbolLocationLayerRenderer implements LocationLayerRenderer {
   }
 
   private void refreshSource() {
+    if (isDisabled) {
+      return;
+    }
+
     // prevents exception when other style has been set with an update in flight
     // https://github.com/maplibre/maplibre-native/issues/3348
     if (!style.isFullyLoaded()) {
@@ -350,5 +355,10 @@ final class SymbolLocationLayerRenderer implements LocationLayerRenderer {
   private void updateAccuracyRadius(float accuracy) {
     locationFeature.addNumberProperty(PROPERTY_ACCURACY_RADIUS, accuracy);
     refreshSource();
+  }
+
+  @Override
+  public void disableLayers() {
+    isDisabled = true;
   }
 }

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
@@ -1072,7 +1072,7 @@ final class NativeMapView implements NativeMap {
   }
 
   @Override
-  public void removeImage(String name) {
+  public void removeImage(@NonNull String name) {
     if (checkState("removeImage")) {
       return;
     }


### PR DESCRIPTION
This is a performance optimization. When the custom puck is used there's no need to run geojson refreshes for the location component since geojson is not really used

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alproton/maplibre-native/61)
<!-- Reviewable:end -->
