### PR TITLE
removed unused method of traffic segments rendering

### DIFF
--- a/include/mbgl/route/route.hpp
+++ b/include/mbgl/route/route.hpp
@@ -41,7 +41,7 @@ class Route {
 public:
     Route() = default;
     Route(const LineString<double>& geometry, const RouteOptions& ropts);
-    bool routeSegmentCreate(const RouteSegmentOptions&, bool useFractionalIndices = false);
+    bool routeSegmentCreate(const RouteSegmentOptions&);
     std::map<double, mbgl::Color> getRouteSegmentColorStops(const RouteType& routeType, const mbgl::Color& routeColor);
     std::map<double, mbgl::Color> getRouteColorStops(const mbgl::Color& routeColor) const;
     std::vector<double> getRouteSegmentDistances() const;

--- a/include/mbgl/route/route_manager.hpp
+++ b/include/mbgl/route/route_manager.hpp
@@ -70,7 +70,6 @@ public:
     bool routeSegmentCreate(const RouteID&, const RouteSegmentOptions&);
     bool routeSetProgressPercent(const RouteID&, double progress);
     double routeSetProgressPoint(const RouteID&, const Point<double>& progressPoint, const Precision& precision);
-    void setUseRouteSegmentIndexFractions(bool useFractions);
     double getTotalDistance(const RouteID& routeID);
     Point<double> getPoint(const RouteID& routeID,
                            double percent,
@@ -129,7 +128,6 @@ private:
     long long totalVanishingRouteElapsedMillis = 0;
     long long numVanisingRouteInvocations = 0;
     bool captureNavStops_ = false;
-    bool useRouteSegmentIndexFractions_ = false;
 };
 }; // namespace route
 

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -1618,7 +1618,6 @@ void NativeMapView::registerNative(jni::JNIEnv& env) {
         METHOD(&NativeMapView::routeProgressSetPoint, "nativeRouteSetProgressPoint"),
         METHOD(&NativeMapView::routeSegmentsClear, "nativeRouteClearSegments"),
         METHOD(&NativeMapView::routeSegmentCreate, "nativeRouteSegmentCreate"),
-        METHOD(&NativeMapView::routeSegmentCreateFractional, "nativeRouteSegmentCreateFractional"),
         METHOD(&NativeMapView::getRenderingStats, "nativeGetRenderingStats"),
         METHOD(&NativeMapView::routeSetVanishing, "nativeRouteSetVanishing"),
         METHOD(&NativeMapView::routeGetVanishing, "nativeRouteGetVanishing"),
@@ -1763,47 +1762,14 @@ jboolean NativeMapView::routeDispose(JNIEnv& env, jint routeID) {
 
 jboolean NativeMapView::routeSegmentCreate(JNIEnv& env,
                                            jint routeID,
-                                           const jni::Object<mbgl::android::geojson::LineString>& segmentGeom,
+                                           jni::jint firstIndex,
+                                           jni::jfloat firstFraction,
+                                           jni::jint lastIndex,
+                                           jni::jfloat lastFraction,
                                            jint color,
                                            jint outerColor,
                                            jint priority) {
     if (routeMgr) {
-        routeMgr->setUseRouteSegmentIndexFractions(false);
-        using namespace mbgl::android::conversion;
-        const auto& linestring = mbgl::android::geojson::LineString::convert(env, segmentGeom);
-        mbgl::route::RouteSegmentOptions rsegopts;
-        rsegopts.geometry = linestring;
-        rsegopts.priority = static_cast<uint32_t>(priority);
-        Converter<mbgl::Color, int> colorConverter;
-        Result<Color> innerSegmentColorRes = colorConverter(env, color);
-        if (innerSegmentColorRes) {
-            mbgl::Color isegcolor = *innerSegmentColorRes;
-            rsegopts.color = {isegcolor.r, isegcolor.g, isegcolor.b, 1.0f};
-        }
-
-        Result<Color> outerSegmentColorRes = colorConverter(env, outerColor);
-        if (outerSegmentColorRes) {
-            mbgl::Color osegcolor = *outerSegmentColorRes;
-            rsegopts.outerColor = {osegcolor.r, osegcolor.g, osegcolor.b, 1.0f};
-        }
-
-        return routeMgr->routeSegmentCreate(RouteID(routeID), rsegopts);
-    }
-
-    return false;
-}
-
-jboolean NativeMapView::routeSegmentCreateFractional(JNIEnv& env,
-                                                     jint routeID,
-                                                     jni::jint firstIndex,
-                                                     jni::jfloat firstFraction,
-                                                     jni::jint lastIndex,
-                                                     jni::jfloat lastFraction,
-                                                     jint color,
-                                                     jint outerColor,
-                                                     jint priority) {
-    if (routeMgr) {
-        routeMgr->setUseRouteSegmentIndexFractions(true);
         using namespace mbgl::android::conversion;
         mbgl::route::RouteSegmentOptions rsegopts;
 

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
@@ -257,20 +257,13 @@ public:
 
     jboolean routeSegmentCreate(JNIEnv& env,
                                 jint routeID,
-                                const jni::Object<mbgl::android::geojson::LineString>& segmentGeom,
+                                jni::jint firstIndex,
+                                jni::jfloat firstFraction,
+                                jni::jint lastIndex,
+                                jni::jfloat lastFraction,
                                 jint color,
                                 jint outerColor,
                                 jint priority);
-
-    jboolean routeSegmentCreateFractional(JNIEnv& env,
-                                          jint routeID,
-                                          jni::jint firstIndex,
-                                          jni::jfloat firstFraction,
-                                          jni::jint lastIndex,
-                                          jni::jfloat lastFraction,
-                                          jint color,
-                                          jint outerColor,
-                                          jint priority);
 
     jboolean routeProgressSet(JNIEnv& env, jni::jint routeID, jni::jdouble progress);
 

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapView.java
@@ -611,29 +611,9 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
    * @return true if the route segment was created successfully, false otherwise. If the route
    * does not exist, false is returned.
    */
-  @Deprecated
   public boolean createRouteSegment(RouteID routeID, RouteSegmentOptions rsopts) {
     if(nativeMapView != null) {
       return nativeMapView.createRouteSegment(routeID, rsopts);
-    }
-
-    return false;
-  }
-
-  /***
-   * Creates a new route segment on the map view. A route segment is defined by the first index and
-   * last index of the route geometry. Finer resolution of the route segment can be achieved by
-   * specifying the first and last index fractions. A route segment is typically used to visualize
-   * traffic zones and is customizable by the client code. Remember to call finalizeRoutes().
-   *
-   * @param routeID the specified routeID for the corresponding route.
-   * @param rsopts the specified visual appearance of the route segment
-   * @return true if the route segment was created successfully, false otherwise. If the route
-   * does not exist, false is returned.
-   */
-  public boolean createRouteSegmentFractional(RouteID routeID, RouteSegmentOptions rsopts) {
-    if(nativeMapView != null) {
-      return nativeMapView.createRouteSegmentFractional(routeID, rsopts);
     }
 
     return false;

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMap.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMap.java
@@ -286,8 +286,6 @@ interface NativeMap {
 
   boolean createRouteSegment(RouteID routeID, RouteSegmentOptions rsopts);
 
-  boolean createRouteSegmentFractional(RouteID routeID, RouteSegmentOptions rsopts);
-
   boolean setRouteProgress(RouteID routeID, double progress);
 
   double setRouteProgressPoint(RouteID routeID, Point point, boolean coarsePrecision);

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
@@ -1212,16 +1212,7 @@ final class NativeMapView implements NativeMap {
   @Override
   public boolean createRouteSegment(RouteID routeID, RouteSegmentOptions rsopts) {
     if(routeID.isValid()) {
-      return nativeRouteSegmentCreate(routeID.getId(), rsopts.geometry, rsopts.color, rsopts.outerColor, rsopts.priority);
-    }
-
-    return false;
-  }
-
-  @Override
-  public boolean createRouteSegmentFractional(RouteID routeID, RouteSegmentOptions rsopts) {
-    if(routeID.isValid()) {
-        return nativeRouteSegmentCreateFractional(routeID.getId(), rsopts.firstIndex, rsopts.firstIndexFraction, rsopts.lastIndex, rsopts.lastIndexFraction, rsopts.color, rsopts.outerColor, rsopts.priority);
+      return nativeRouteSegmentCreate(routeID.getId(), rsopts.firstIndex, rsopts.firstIndexFraction, rsopts.lastIndex, rsopts.lastIndexFraction, rsopts.color, rsopts.outerColor, rsopts.priority);
     }
 
     return false;
@@ -1750,10 +1741,7 @@ final class NativeMapView implements NativeMap {
   private native boolean nativeRouteDispose(int routeID);
 
   @Keep
-  private native boolean nativeRouteSegmentCreate(int routeID, LineString segmentGeometry, int color, int outerColor, int priority);
-
-  @Keep
-  private native boolean nativeRouteSegmentCreateFractional(int routeID, int firstIndex, float firstIndexFraction, int lastIndex, float lastIndexFraction, int color, int outerColor, int priority);
+  private native boolean nativeRouteSegmentCreate(int routeID, int firstIndex, float firstIndexFraction, int lastIndex, float lastIndexFraction, int color, int outerColor, int priority);
 
   @Keep
   private native boolean nativeRouteSetProgress(int routeID, double progress);

--- a/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/routes/RouteUtils.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/routes/RouteUtils.kt
@@ -227,7 +227,7 @@ class RouteUtils {
                 rsopts.firstIndexFraction = trafficBlk.firstIndexFractional
                 rsopts.lastIndex = trafficBlk.lastIndex
                 rsopts.lastIndexFraction = trafficBlk.lastIndexFractional
-                mapView.createRouteSegmentFractional(routeID, rsopts)
+                mapView.createRouteSegment(routeID, rsopts)
             }
             mapView.finalizeRoutes()
         }

--- a/platform/glfw/tests/route_add_traffic_test.cpp
+++ b/platform/glfw/tests/route_add_traffic_test.cpp
@@ -53,7 +53,6 @@ bool RouteAddTrafficTest::produceTestCommands([[maybe_unused]] mbgl::Map *map, [
 
         testCommands_.push([&]([[maybe_unused]] mbgl::Map *map, [[maybe_unused]] GLFWView *view) {
             std::vector<TrafficBlock> trafficBlks;
-            bool useIndexFractions = true;
             for (const auto &iter : routeMap_) {
                 const auto &routeID = iter.first;
                 const auto &route = iter.second;
@@ -103,7 +102,6 @@ bool RouteAddTrafficTest::produceTestCommands([[maybe_unused]] mbgl::Map *map, [
 
                 // clear the route segments and create new ones from the traffic blocks
                 rmptr_->routeClearSegments(routeID);
-                rmptr_->setUseRouteSegmentIndexFractions(useIndexFractions);
                 for (size_t i = 0; i < trafficBlks.size(); i++) {
                     mbgl::route::RouteSegmentOptions rsegopts;
                     uint32_t coloridx = i % (trafficBlks.size() - 1);

--- a/platform/glfw/tests/route_pick_test.cpp
+++ b/platform/glfw/tests/route_pick_test.cpp
@@ -121,7 +121,6 @@ bool RoutePickTest::produceTestCommands(mbgl::Map* map, GLFWView* view) {
             const RouteID routeID = rmptr_->routeCreate(rd.points, routeOpts);
             assert(routeID.isValid() && "invalid route ID created");
             rmptr_->finalize();
-            rmptr_->setUseRouteSegmentIndexFractions(true);
             setVanishingRouteID(routeID);
             routeMap_[routeID] = rd;
         });

--- a/platform/glfw/tests/route_traffic_priority_test.cpp
+++ b/platform/glfw/tests/route_traffic_priority_test.cpp
@@ -76,7 +76,6 @@ void RouteTrafficPriorityTest::setTrafficCase(const RouteSegmentTestCases& testc
     TrafficBlock block2;
     const RouteID& routeID = routeMap_.begin()->first;
     const RouteData& route = routeMap_.at(routeID);
-    bool useFractionalRouteSegments = true;
     const auto& routeTrafficUpdate = [&](TrafficBlock& block,
                                          std::pair<uint32_t, double> firstIndexFraction,
                                          std::pair<uint32_t, double> lastIndexFraction) {
@@ -88,92 +87,58 @@ void RouteTrafficPriorityTest::setTrafficCase(const RouteSegmentTestCases& testc
 
     switch (testcase) {
         case RouteSegmentTestCases::Blk1LowPriorityIntersecting: {
-            if (!useFractionalRouteSegments) {
-                block1.block = {route.getPoint(0.0), route.getPoint(0.25), route.getPoint(0.5)};
-            } else {
-                std::pair<uint32_t, double> firstIndexFraction1 = route.getIntervalFraction(0.0);
-                std::pair<uint32_t, double> lastIndexFraction1 = route.getIntervalFraction(0.5);
-                routeTrafficUpdate(block1, firstIndexFraction1, lastIndexFraction1);
-            }
-
+            std::pair<uint32_t, double> firstIndexFraction1 = route.getIntervalFraction(0.0);
+            std::pair<uint32_t, double> lastIndexFraction1 = route.getIntervalFraction(0.5);
+            routeTrafficUpdate(block1, firstIndexFraction1, lastIndexFraction1);
             block1.priority = 0;
             block1.color = routeColorTable.at(RouteMapLowTrafficColor);
 
-            if (!useFractionalRouteSegments) {
-                block2.block = {route.getPoint(0.2), route.getPoint(0.7), route.getPoint(0.8)};
-            } else {
-                std::pair<uint32_t, double> firstIndexFraction2 = route.getIntervalFraction(0.2);
-                std::pair<uint32_t, double> lastIndexFraction2 = route.getIntervalFraction(0.8);
-                routeTrafficUpdate(block2, firstIndexFraction2, lastIndexFraction2);
-            }
-
+            std::pair<uint32_t, double> firstIndexFraction2 = route.getIntervalFraction(0.2);
+            std::pair<uint32_t, double> lastIndexFraction2 = route.getIntervalFraction(0.8);
+            routeTrafficUpdate(block2, firstIndexFraction2, lastIndexFraction2);
             block2.priority = 1;
             block2.color = routeColorTable.at(RouteMapModerateTrafficColor);
         } break;
 
         case RouteSegmentTestCases::Blk1HighPriorityIntersecting: {
-            if (!useFractionalRouteSegments) {
-                block1.block = {route.getPoint(0.0), route.getPoint(0.25), route.getPoint(0.5)};
-            } else {
-                std::pair<uint32_t, double> firstIndexFraction1 = route.getIntervalFraction(0.0);
-                std::pair<uint32_t, double> lastIndexFraction1 = route.getIntervalFraction(0.5);
-                routeTrafficUpdate(block1, firstIndexFraction1, lastIndexFraction1);
-            }
+            std::pair<uint32_t, double> firstIndexFraction1 = route.getIntervalFraction(0.0);
+            std::pair<uint32_t, double> lastIndexFraction1 = route.getIntervalFraction(0.5);
+            routeTrafficUpdate(block1, firstIndexFraction1, lastIndexFraction1);
             block1.priority = 1;
             block1.color = routeColorTable.at(RouteMapLowTrafficColor);
 
-            if (!useFractionalRouteSegments) {
-                block2.block = {route.getPoint(0.2), route.getPoint(0.7), route.getPoint(0.8)};
-            } else {
-                std::pair<uint32_t, double> firstIndexFraction2 = route.getIntervalFraction(0.2);
-                std::pair<uint32_t, double> lastIndexFraction2 = route.getIntervalFraction(0.8);
-                routeTrafficUpdate(block2, firstIndexFraction2, lastIndexFraction2);
-            }
+            std::pair<uint32_t, double> firstIndexFraction2 = route.getIntervalFraction(0.2);
+            std::pair<uint32_t, double> lastIndexFraction2 = route.getIntervalFraction(0.8);
+            routeTrafficUpdate(block2, firstIndexFraction2, lastIndexFraction2);
             block2.priority = 0;
             block2.color = routeColorTable.at(RouteMapModerateTrafficColor);
         } break;
 
         case RouteSegmentTestCases::Blk12SameColorIntersecting: {
-            if (!useFractionalRouteSegments) {
-                block1.block = {route.getPoint(0.0), route.getPoint(0.25), route.getPoint(0.5)};
-            } else {
-                std::pair<uint32_t, double> firstIndexFraction1 = route.getIntervalFraction(0.0);
-                std::pair<uint32_t, double> lastIndexFraction1 = route.getIntervalFraction(0.5);
-                routeTrafficUpdate(block1, firstIndexFraction1, lastIndexFraction1);
-            }
+            std::pair<uint32_t, double> firstIndexFraction1 = route.getIntervalFraction(0.0);
+            std::pair<uint32_t, double> lastIndexFraction1 = route.getIntervalFraction(0.5);
+            routeTrafficUpdate(block1, firstIndexFraction1, lastIndexFraction1);
             block1.priority = 0;
             block1.color = routeColorTable.at(RouteMapLowTrafficColor);
 
-            if (!useFractionalRouteSegments) {
-                block2.block = {route.getPoint(0.2), route.getPoint(0.7), route.getPoint(0.8)};
-            } else {
-                std::pair<uint32_t, double> firstIndexFraction2 = route.getIntervalFraction(0.2);
-                std::pair<uint32_t, double> lastIndexFraction2 = route.getIntervalFraction(0.8);
-                routeTrafficUpdate(block2, firstIndexFraction2, lastIndexFraction2);
-            }
+            std::pair<uint32_t, double> firstIndexFraction2 = route.getIntervalFraction(0.2);
+            std::pair<uint32_t, double> lastIndexFraction2 = route.getIntervalFraction(0.8);
+            routeTrafficUpdate(block2, firstIndexFraction2, lastIndexFraction2);
             block2.priority = 1;
             block2.color = routeColorTable.at(RouteMapLowTrafficColor);
 
         } break;
 
         case RouteSegmentTestCases::Blk12NonIntersecting: {
-            if (!useFractionalRouteSegments) {
-                block1.block = {route.getPoint(0.0), route.getPoint(0.25), route.getPoint(0.5)};
-            } else {
-                std::pair<uint32_t, double> firstIndexFraction1 = route.getIntervalFraction(0.0);
-                std::pair<uint32_t, double> lastIndexFraction1 = route.getIntervalFraction(0.5);
-                routeTrafficUpdate(block1, firstIndexFraction1, lastIndexFraction1);
-            }
+            std::pair<uint32_t, double> firstIndexFraction1 = route.getIntervalFraction(0.0);
+            std::pair<uint32_t, double> lastIndexFraction1 = route.getIntervalFraction(0.5);
+            routeTrafficUpdate(block1, firstIndexFraction1, lastIndexFraction1);
             block1.priority = 0;
             block1.color = routeColorTable.at(RouteMapLowTrafficColor);
 
-            if (!useFractionalRouteSegments) {
-                block2.block = {route.getPoint(0.6), route.getPoint(0.7), route.getPoint(0.8)};
-            } else {
-                std::pair<uint32_t, double> firstIndexFraction2 = route.getIntervalFraction(0.6);
-                std::pair<uint32_t, double> lastIndexFraction2 = route.getIntervalFraction(0.8);
-                routeTrafficUpdate(block2, firstIndexFraction2, lastIndexFraction2);
-            }
+            std::pair<uint32_t, double> firstIndexFraction2 = route.getIntervalFraction(0.6);
+            std::pair<uint32_t, double> lastIndexFraction2 = route.getIntervalFraction(0.8);
+            routeTrafficUpdate(block2, firstIndexFraction2, lastIndexFraction2);
             block2.priority = 0;
             block2.color = routeColorTable.at(RouteMapModerateTrafficColor);
 
@@ -185,7 +150,6 @@ void RouteTrafficPriorityTest::setTrafficCase(const RouteSegmentTestCases& testc
 
     std::vector<TrafficBlock> fixture{block1, block2};
     rmptr_->routeClearSegments(routeID);
-    rmptr_->setUseRouteSegmentIndexFractions(useFractionalRouteSegments);
     for (size_t i = 0; i < fixture.size(); i++) {
         mbgl::route::RouteSegmentOptions rsegopts;
         rsegopts.color = fixture[i].color;

--- a/src/mbgl/route/route.cpp
+++ b/src/mbgl/route/route.cpp
@@ -441,30 +441,18 @@ bool Route::hasRouteSegments() const {
     return !segments_.empty();
 }
 
-bool Route::routeSegmentCreate(const RouteSegmentOptions& rsegopts, bool useFractionalIndices) {
+bool Route::routeSegmentCreate(const RouteSegmentOptions& rsegopts) {
     std::vector<double> normalizedPositions;
-    if (useFractionalIndices) {
-        const auto& getNormalizedPosition = [&](uint32_t index, float indexFraction) {
-            double indexDistanceAlongRoute = cumulativeIntervalDistances_[index] +
-                                             (indexFraction * intervalLengths_[index]);
+    const auto& getNormalizedPosition = [&](uint32_t index, float indexFraction) {
+        double indexDistanceAlongRoute = cumulativeIntervalDistances_[index] +
+                                         (indexFraction * intervalLengths_[index]);
 
-            double normalizedDistance = indexDistanceAlongRoute / totalLength_;
-            return normalizedDistance;
-        };
+        double normalizedDistance = indexDistanceAlongRoute / totalLength_;
+        return normalizedDistance;
+    };
 
-        normalizedPositions = {getNormalizedPosition(rsegopts.firstIndex, rsegopts.firstIndexFraction),
-                               getNormalizedPosition(rsegopts.lastIndex, rsegopts.lastIndexFraction)};
-    } else {
-        normalizedPositions.reserve(rsegopts.geometry.size());
-        for (const auto& segpt : rsegopts.geometry) {
-            if (std::isnan(segpt.x) || std::isnan(segpt.y)) {
-                Log::Error(Event::Route, "Route segment geometry contains NaN point");
-                return false;
-            }
-            double normalized = getProgressPercent(segpt, Precision::Fine, false);
-            normalizedPositions.push_back(normalized);
-        }
-    }
+    normalizedPositions = {getNormalizedPosition(rsegopts.firstIndex, rsegopts.firstIndexFraction),
+                           getNormalizedPosition(rsegopts.lastIndex, rsegopts.lastIndexFraction)};
 
     RouteSegment routeSeg(rsegopts, normalizedPositions);
 

--- a/src/mbgl/route/route_manager.cpp
+++ b/src/mbgl/route/route_manager.cpp
@@ -420,23 +420,18 @@ bool RouteManager::routeSet(const RouteID& routeID, const LineString<double>& ge
     return false;
 }
 
-void RouteManager::setUseRouteSegmentIndexFractions(bool useFractions) {
-    useRouteSegmentIndexFractions_ = useFractions;
-}
-
 bool RouteManager::routeSegmentCreate(const RouteID& routeID, const RouteSegmentOptions& routeSegOpts) {
     assert(routeID.isValid() && "Invalid route ID");
     assert(routeMap_.find(routeID) != routeMap_.end() && "Route not found internally");
     if (routeID.isValid() && routeMap_.find(routeID) != routeMap_.end()) {
         // route segments must have atleast 2 points
-        if (useRouteSegmentIndexFractions_ &&
-            (routeSegOpts.firstIndex == INVALID_UINT || routeSegOpts.lastIndex == INVALID_UINT ||
-             routeSegOpts.firstIndexFraction < 0.0f || routeSegOpts.lastIndexFraction < 0.0f ||
-             routeSegOpts.firstIndexFraction > 1.0f || routeSegOpts.lastIndexFraction > 1.0f)) {
+        if (routeSegOpts.firstIndex == INVALID_UINT || routeSegOpts.lastIndex == INVALID_UINT ||
+            routeSegOpts.firstIndexFraction < 0.0f || routeSegOpts.lastIndexFraction < 0.0f ||
+            routeSegOpts.firstIndexFraction > 1.0f || routeSegOpts.lastIndexFraction > 1.0f) {
             return false;
         }
 
-        bool success = routeMap_[routeID].routeSegmentCreate(routeSegOpts, useRouteSegmentIndexFractions_);
+        bool success = routeMap_[routeID].routeSegmentCreate(routeSegOpts);
         if (success) {
             stats_.numRouteSegments++;
             validateAddToDirtyBin(routeID, DirtyType::dtRouteSegments);


### PR DESCRIPTION
Nav side uses fractional indices for traffic segments that is sent directly from google auto SDK which is a polyline index and local fractional value within that polyline index. Before that nav was unnecessarily calculating points on the route that represented a traffic segment. This was done prior to create polylines for traffic segments which is not how we render traffic in MLN for routes.

MLN route API supported both. We have code in Nav that now passes efficiently directly from auto sdk. There is no reason keep around unused and un-needed code.

[Passed all graphics tests]

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alproton/maplibre-native/62)
<!-- Reviewable:end -->
