### PR TITLE
Add thread priority override

### DIFF
--- a/include/mbgl/gfx/custom_puck.hpp
+++ b/include/mbgl/gfx/custom_puck.hpp
@@ -74,6 +74,8 @@ private:
     // The style is updated in the UI thread and is used in the rendering thread
     // This mutex ensures the puck is not modified by the UI thread while being rendered in the render thread
     std::mutex styleMutex;
+    // Used to check if camera tracking has changed
+    bool isCameraTracking = false;
 };
 
 } // namespace gfx

--- a/include/mbgl/util/thread.hpp
+++ b/include/mbgl/util/thread.hpp
@@ -163,5 +163,22 @@ private:
 /// Settings' platform::EXPERIMENTAL_THREAD_PRIORITY_* value.
 std::function<void()> makeThreadPrioritySetter(std::string threadType);
 
+// Override threads priority
+struct ThreadPriorityOverrider {
+    // This enum mirrors the Java enum ThreadPriorityOverride in the class MapLibreMapOptions
+    enum class ThreadPriorityOverride {
+        NONE = 0,
+        FORCE_LOW = 1,
+        FORCE_HIGH = 2,
+    };
+
+    ThreadPriorityOverrider(int threadPriorityOverride);
+
+    static ThreadPriorityOverride getPriority() { return threadPriorityOverride; }
+
+private:
+    static ThreadPriorityOverride threadPriorityOverride;
+};
+
 } // namespace util
 } // namespace mbgl

--- a/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
@@ -41,8 +41,10 @@ namespace android {
 MapRenderer::MapRenderer(jni::JNIEnv& _env,
                          const jni::Object<MapRenderer>& obj,
                          jni::jfloat pixelRatio_,
-                         const jni::String& localIdeographFontFamily_)
+                         const jni::String& localIdeographFontFamily_,
+                         jni::jint threadPriorityOverride)
     : javaPeer(_env, obj),
+      threadPriorityOverrider(threadPriorityOverride),
       pixelRatio(pixelRatio_),
       localIdeographFontFamily(localIdeographFontFamily_ ? jni::Make<std::string>(_env, localIdeographFontFamily_)
                                                          : std::optional<std::string>{}),
@@ -351,7 +353,7 @@ void MapRenderer::registerNative(jni::JNIEnv& env) {
         env,
         javaClass,
         "nativePtr",
-        jni::MakePeer<MapRenderer, const jni::Object<MapRenderer>&, jni::jfloat, const jni::String&>,
+        jni::MakePeer<MapRenderer, const jni::Object<MapRenderer>&, jni::jfloat, const jni::String&, jni::jint>,
         "nativeInitialize",
         "finalize",
         METHOD(&MapRenderer::render, "nativeRender"),

--- a/platform/android/MapLibreAndroid/src/cpp/map_renderer.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/map_renderer.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/actor/scheduler.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/gfx/rendering_stats.hpp>
+#include <mbgl/util/thread.hpp>
 
 #include <memory>
 #include <mutex>
@@ -50,7 +51,8 @@ public:
     MapRenderer(jni::JNIEnv& _env,
                 const jni::Object<MapRenderer>&,
                 jni::jfloat pixelRatio,
-                const jni::String& localIdeographFontFamily);
+                const jni::String& localIdeographFontFamily,
+                int threadPriorityOverride);
 
     ~MapRenderer() override;
 
@@ -134,6 +136,8 @@ private:
 
 private:
     jni::WeakReference<jni::Object<MapRenderer>, jni::EnvAttachingDeleter> javaPeer;
+
+    util::ThreadPriorityOverrider threadPriorityOverrider;
 
     float pixelRatio;
     std::optional<std::string> localIdeographFontFamily;

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationCameraController.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationCameraController.java
@@ -14,6 +14,7 @@ import org.maplibre.android.gestures.AndroidGesturesManager;
 import org.maplibre.android.gestures.MoveGestureDetector;
 import org.maplibre.android.gestures.RotateGestureDetector;
 import org.maplibre.android.location.modes.CameraMode;
+import org.maplibre.android.log.Logger;
 import org.maplibre.android.maps.MapLibreMap;
 import org.maplibre.android.maps.Transform;
 
@@ -28,6 +29,8 @@ import org.maplibre.android.camera.CameraUpdateFactory;
 import org.maplibre.android.geometry.LatLng;
 
 final class LocationCameraController {
+
+  private static final String TAG = "Mbgl-LocationCameraController";
 
   @CameraMode.Mode
   private int cameraMode;
@@ -107,6 +110,7 @@ final class LocationCameraController {
                      long transitionDuration,
                      @Nullable Double zoom, @Nullable Double bearing, @Nullable Double tilt,
                      @Nullable OnLocationCameraTransitionListener internalTransitionListener) {
+    Logger.w(TAG, "Setting camera mode to " + cameraMode);
     if (this.cameraMode == cameraMode) {
       if (internalTransitionListener != null) {
         internalTransitionListener.onLocationCameraTransitionFinished(cameraMode);

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapLibreMapOptions.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapLibreMapOptions.java
@@ -36,6 +36,20 @@ import java.util.Arrays;
  */
 public class MapLibreMapOptions implements Parcelable {
 
+  public enum ThreadPriorityOverride {
+      NONE(0), FORCE_LOW(1), FORCE_HIGH(2);
+
+      private final int code;
+
+      ThreadPriorityOverride(int code) {
+            this.code = code;
+      }
+
+      public int getCode() {
+          return code;
+      }
+  }
+
   private static final int LIGHT_GRAY = 0xFFF0E9E1; // RGB(240, 233, 225))
   private static final float FOUR_DP = 4f;
   private static final float NINETY_TWO_DP = 92f;
@@ -94,6 +108,9 @@ public class MapLibreMapOptions implements Parcelable {
 
   private boolean crossSourceCollisions = true;
 
+  private int threadPriorityOverride = 0;
+
+
   /**
    * Creates a new MapLibreMapOptions object.
    *
@@ -151,6 +168,7 @@ public class MapLibreMapOptions implements Parcelable {
     pixelRatio = in.readFloat();
     foregroundLoadColor = in.readInt();
     crossSourceCollisions = in.readByte() != 0;
+    threadPriorityOverride = in.readInt();
   }
 
   /**
@@ -731,6 +749,18 @@ public class MapLibreMapOptions implements Parcelable {
   }
 
   /**
+   * Override thread priorities
+   *
+   * @param threadPriorityOverride override thread priority
+   * @return This
+   */
+  @NonNull
+  public MapLibreMapOptions threadPriorityOverride(ThreadPriorityOverride threadPriorityOverride) {
+    this.threadPriorityOverride = threadPriorityOverride.getCode();
+    return this;
+  }
+
+  /**
    * Enable local ideograph font family, defaults to true.
    *
    * @param enabled true to enable, false to disable
@@ -819,6 +849,15 @@ public class MapLibreMapOptions implements Parcelable {
    */
   public boolean getCrossSourceCollisions() {
     return crossSourceCollisions;
+  }
+
+  /**
+   * Return thread priority override
+   *
+   * @return thread priority override
+   */
+  public int getThreadPriorityOverride() {
+    return threadPriorityOverride;
   }
 
   /**
@@ -1205,6 +1244,7 @@ public class MapLibreMapOptions implements Parcelable {
     dest.writeFloat(pixelRatio);
     dest.writeInt(foregroundLoadColor);
     dest.writeByte((byte) (crossSourceCollisions ? 1 : 0));
+    dest.writeInt(threadPriorityOverride);
   }
 
   @Override
@@ -1325,6 +1365,10 @@ public class MapLibreMapOptions implements Parcelable {
       return false;
     }
 
+    if (threadPriorityOverride != options.threadPriorityOverride) {
+      return false;
+    }
+
     return false;
   }
 
@@ -1372,6 +1416,7 @@ public class MapLibreMapOptions implements Parcelable {
     result = 31 * result + Arrays.hashCode(localIdeographFontFamilies);
     result = 31 * result + (int) pixelRatio;
     result = 31 * result + (crossSourceCollisions ? 1 : 0);
+    result = 31 * result + threadPriorityOverride;
     return result;
   }
 }

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/renderer/MapRenderer.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/renderer/MapRenderer.java
@@ -56,26 +56,27 @@ public abstract class MapRenderer implements MapRendererScheduler {
 
     MapRenderer renderer = null;
     String localFontFamily = options.getLocalIdeographFontFamily();
+    int threadPriorityOverride = options.getThreadPriorityOverride();
 
     if (options.getTextureMode()) {
       TextureView textureView = new TextureView(context);
       boolean translucentSurface = options.getTranslucentTextureSurface();
       renderer = MapRendererFactory.newTextureViewMapRenderer(context, textureView, localFontFamily,
-              translucentSurface, initCallback);
+              translucentSurface, initCallback, threadPriorityOverride);
     } else {
       boolean renderSurfaceOnTop = options.getRenderSurfaceOnTop();
       renderer = MapRendererFactory.newSurfaceViewMapRenderer(context, localFontFamily,
-              renderSurfaceOnTop, initCallback);
+              renderSurfaceOnTop, initCallback, threadPriorityOverride);
     }
 
     return renderer;
   }
 
-  public MapRenderer(@NonNull Context context, String localIdeographFontFamily) {
+  public MapRenderer(@NonNull Context context, String localIdeographFontFamily, int threadPriorityOverride) {
     float pixelRatio = context.getResources().getDisplayMetrics().density;
 
     // Initialize native peer
-    nativeInitialize(this, pixelRatio, localIdeographFontFamily);
+    nativeInitialize(this, pixelRatio, localIdeographFontFamily, threadPriorityOverride);
   }
 
   public abstract View getView();
@@ -164,7 +165,8 @@ public abstract class MapRenderer implements MapRendererScheduler {
 
   private native void nativeInitialize(MapRenderer self,
                                        float pixelRatio,
-                                       String localIdeographFontFamily);
+                                       String localIdeographFontFamily,
+                                       int threadPriorityOverride);
 
   @CallSuper
   @Override

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/renderer/surfaceview/SurfaceViewMapRenderer.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/renderer/surfaceview/SurfaceViewMapRenderer.java
@@ -21,8 +21,9 @@ public class SurfaceViewMapRenderer extends MapRenderer {
 
   public SurfaceViewMapRenderer(Context context,
                                 MapLibreSurfaceView surfaceView,
-                                String localIdeographFontFamily) {
-    super(context, localIdeographFontFamily);
+                                String localIdeographFontFamily,
+                                int threadPriorityOverride) {
+    super(context, localIdeographFontFamily, threadPriorityOverride);
     this.surfaceView = surfaceView;
 
     surfaceView.setDetachedListener(new MapLibreSurfaceView.OnSurfaceViewDetachedListener() {

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/renderer/textureview/TextureViewMapRenderer.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/renderer/textureview/TextureViewMapRenderer.java
@@ -31,8 +31,9 @@ public class TextureViewMapRenderer extends MapRenderer {
   public TextureViewMapRenderer(@NonNull Context context,
                                 @NonNull TextureView textureView,
                                 String localIdeographFontFamily,
-                                boolean translucentSurface) {
-    super(context, localIdeographFontFamily);
+                                boolean translucentSurface,
+                                int threadPriorityOverride) {
+    super(context, localIdeographFontFamily, threadPriorityOverride);
     this.textureView = textureView;
     this.translucentSurface = translucentSurface;
 

--- a/platform/android/MapLibreAndroid/src/opengl/java/org/maplibre/android/maps/renderer/MapRendererFactory.java
+++ b/platform/android/MapLibreAndroid/src/opengl/java/org/maplibre/android/maps/renderer/MapRendererFactory.java
@@ -17,10 +17,10 @@ import org.maplibre.android.maps.renderer.textureview.TextureViewMapRenderer;
 public class MapRendererFactory {
   public static TextureViewMapRenderer newTextureViewMapRenderer(@NonNull Context context, TextureView textureView,
                                                                  String localFontFamily, boolean translucentSurface,
-                                                                 Runnable initCallback) {
+                                                                 Runnable initCallback, int threadPriorityOverride) {
 
     TextureViewMapRenderer mapRenderer = new TextureViewMapRenderer(context, textureView,
-            localFontFamily, translucentSurface) {
+            localFontFamily, translucentSurface, threadPriorityOverride) {
       @Override
       protected void onSurfaceCreated(Surface surface) {
         initCallback.run();
@@ -33,12 +33,13 @@ public class MapRendererFactory {
   }
 
   public static SurfaceViewMapRenderer newSurfaceViewMapRenderer(@NonNull Context context, String localFontFamily,
-                                                                 boolean renderSurfaceOnTop, Runnable initCallback) {
+                                                                 boolean renderSurfaceOnTop, Runnable initCallback,
+                                                                 int threadPriorityOverride) {
 
     MapLibreGLSurfaceView surfaceView = new MapLibreGLSurfaceView(context);
     surfaceView.setZOrderMediaOverlay(renderSurfaceOnTop);
 
-    return new GLSurfaceViewMapRenderer(context, surfaceView, localFontFamily) {
+    return new GLSurfaceViewMapRenderer(context, surfaceView, localFontFamily, threadPriorityOverride) {
       @Override
       public void onSurfaceCreated(Surface surface) {
         initCallback.run();

--- a/platform/android/MapLibreAndroid/src/opengl/java/org/maplibre/android/maps/renderer/surfaceview/GLSurfaceViewMapRenderer.java
+++ b/platform/android/MapLibreAndroid/src/opengl/java/org/maplibre/android/maps/renderer/surfaceview/GLSurfaceViewMapRenderer.java
@@ -12,8 +12,9 @@ public class GLSurfaceViewMapRenderer extends SurfaceViewMapRenderer {
 
   public GLSurfaceViewMapRenderer(Context context,
                                 @NonNull MapLibreGLSurfaceView surfaceView,
-                                String localIdeographFontFamily) {
-    super(context, surfaceView, localIdeographFontFamily);
+                                String localIdeographFontFamily,
+                                int threadPriorityOverride) {
+    super(context, surfaceView, localIdeographFontFamily, threadPriorityOverride);
 
     surfaceView.setEGLContextFactory(new EGLContextFactory());
     surfaceView.setEGLWindowSurfaceFactory(new EGLWindowSurfaceFactory());

--- a/platform/android/MapLibreAndroid/src/vulkan/java/org/maplibre/android/maps/renderer/MapRendererFactory.java
+++ b/platform/android/MapLibreAndroid/src/vulkan/java/org/maplibre/android/maps/renderer/MapRendererFactory.java
@@ -17,10 +17,10 @@ import org.maplibre.android.maps.renderer.textureview.VulkanTextureViewRenderThr
 public class MapRendererFactory {
   public static TextureViewMapRenderer newTextureViewMapRenderer(@NonNull Context context, TextureView textureView,
                                                                  String localFontFamily, boolean translucentSurface,
-                                                                 Runnable initCallback) {
+                                                                 Runnable initCallback, int threadPriorityOverride) {
 
     TextureViewMapRenderer mapRenderer = new TextureViewMapRenderer(context, textureView,
-            localFontFamily, translucentSurface) {
+            localFontFamily, translucentSurface, threadPriorityOverride) {
       @Override
       protected void onSurfaceCreated(Surface surface) {
         initCallback.run();
@@ -33,12 +33,13 @@ public class MapRendererFactory {
   }
 
   public static SurfaceViewMapRenderer newSurfaceViewMapRenderer(@NonNull Context context, String localFontFamily,
-                                                                 boolean renderSurfaceOnTop, Runnable initCallback) {
+                                                                 boolean renderSurfaceOnTop, Runnable initCallback,
+                                                                 int threadPriorityOverride) {
 
     MapLibreVulkanSurfaceView surfaceView = new MapLibreVulkanSurfaceView(context);
     surfaceView.setZOrderMediaOverlay(renderSurfaceOnTop);
 
-    return new VulkanSurfaceViewMapRenderer(context, surfaceView, localFontFamily) {
+    return new VulkanSurfaceViewMapRenderer(context, surfaceView, localFontFamily, threadPriorityOverride) {
       @Override
       public void onSurfaceCreated(Surface surface) {
         initCallback.run();

--- a/platform/android/MapLibreAndroid/src/vulkan/java/org/maplibre/android/maps/renderer/surfaceview/VulkanSurfaceViewMapRenderer.java
+++ b/platform/android/MapLibreAndroid/src/vulkan/java/org/maplibre/android/maps/renderer/surfaceview/VulkanSurfaceViewMapRenderer.java
@@ -7,8 +7,9 @@ public class VulkanSurfaceViewMapRenderer extends SurfaceViewMapRenderer {
 
   public VulkanSurfaceViewMapRenderer(Context context,
                                 @NonNull MapLibreVulkanSurfaceView surfaceView,
-                                String localIdeographFontFamily) {
-    super(context, surfaceView, localIdeographFontFamily);
+                                String localIdeographFontFamily,
+                                int threadPriorityOverride) {
+    super(context, surfaceView, localIdeographFontFamily, threadPriorityOverride);
 
     this.surfaceView.setRenderer(this);
   }

--- a/platform/default/src/mbgl/util/thread.cpp
+++ b/platform/default/src/mbgl/util/thread.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/util/platform.hpp>
 #include <mbgl/platform/thread.hpp>
 #include <mbgl/util/logging.hpp>
+#include <mbgl/util/thread.hpp>
 
 #include <string>
 
@@ -31,6 +32,12 @@ void setCurrentThreadName(const std::string& name) {
 }
 
 void makeThreadLowPriority() {
+    if (util::ThreadPriorityOverrider::getPriority() ==
+        util::ThreadPriorityOverrider::ThreadPriorityOverride::FORCE_HIGH) {
+        makeThreadHighPriority();
+        return;
+    }
+
 #ifdef SCHED_IDLE
     struct sched_param param;
     param.sched_priority = 0;
@@ -42,6 +49,12 @@ void makeThreadLowPriority() {
 }
 
 void makeThreadHighPriority() {
+    if (util::ThreadPriorityOverrider::getPriority() ==
+        util::ThreadPriorityOverrider::ThreadPriorityOverride::FORCE_LOW) {
+        makeThreadLowPriority();
+        return;
+    }
+
     setCurrentThreadPriority(-20);
 }
 
@@ -50,6 +63,17 @@ double getCurrentThreadPriority() {
 }
 
 void setCurrentThreadPriority(double priority) {
+    if (util::ThreadPriorityOverrider::getPriority() ==
+        util::ThreadPriorityOverrider::ThreadPriorityOverride::FORCE_HIGH) {
+        makeThreadHighPriority();
+        return;
+    }
+    if (util::ThreadPriorityOverrider::getPriority() ==
+        util::ThreadPriorityOverrider::ThreadPriorityOverride::FORCE_LOW) {
+        makeThreadLowPriority();
+        return;
+    }
+
     if (setpriority(PRIO_PROCESS, 0, int(priority)) < 0) {
         Log::Warning(Event::General, "Couldn't set thread priority");
     }

--- a/platform/windows/src/thread.cpp
+++ b/platform/windows/src/thread.cpp
@@ -3,6 +3,7 @@
 #include <mbgl/util/platform.hpp>
 #include <mbgl/platform/thread.hpp>
 #include <mbgl/util/logging.hpp>
+#include <mbgl/util/thread.hpp>
 
 #include <string>
 
@@ -69,12 +70,24 @@ void setCurrentThreadName(const std::string& name) {
 }
 
 void makeThreadLowPriority() {
+    if (util::ThreadPriorityOverrider::getPriority() ==
+        util::ThreadPriorityOverrider::ThreadPriorityOverride::FORCE_HIGH) {
+        makeThreadHighPriority();
+        return;
+    }
+
     if (!SetThreadPriority(GetCurrentThread(), THREAD_MODE_BACKGROUND_BEGIN)) {
         Log::Warning(Event::General, "Couldn't set thread scheduling policy");
     }
 }
 
 void makeThreadHighPriority() {
+    if (util::ThreadPriorityOverrider::getPriority() ==
+        util::ThreadPriorityOverrider::ThreadPriorityOverride::FORCE_LOW) {
+        makeThreadLowPriority();
+        return;
+    }
+
     if (!SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL)) {
         Log::Warning(Event::General, "Couldn't set thread scheduling policy");
     }
@@ -85,6 +98,17 @@ double getCurrentThreadPriority() {
 }
 
 void setCurrentThreadPriority(double priority) {
+    if (util::ThreadPriorityOverrider::getPriority() ==
+        util::ThreadPriorityOverrider::ThreadPriorityOverride::FORCE_HIGH) {
+        makeThreadHighPriority();
+        return;
+    }
+    if (util::ThreadPriorityOverrider::getPriority() ==
+        util::ThreadPriorityOverrider::ThreadPriorityOverride::FORCE_LOW) {
+        makeThreadLowPriority();
+        return;
+    }
+
     if (!SetThreadPriority(GetCurrentThread(), int(priority))) {
         Log::Warning(Event::General, "Couldn't set thread priority");
     }

--- a/src/mbgl/gfx/custom_puck.cpp
+++ b/src/mbgl/gfx/custom_puck.cpp
@@ -1,6 +1,7 @@
 
 #include <mbgl/gfx/custom_puck.hpp>
 #include <mbgl/util/io.hpp>
+#include <mbgl/util/logging.hpp>
 #include <numbers>
 #include <mutex>
 
@@ -54,6 +55,12 @@ void CustomPuck::draw(const TransformState& transform) {
     const auto& state = getState();
     if (!state.enabled) {
         return;
+    }
+
+    if (state.cameraTracking != isCameraTracking) {
+        isCameraTracking = state.cameraTracking;
+        Log::Warning(Event::General,
+                     std::string("Puck displayed with camera tracking ") + (isCameraTracking ? "enabled" : "disabled"));
     }
 
     float bearing = static_cast<float>(-state.bearing * std::numbers::pi / 180.0 - transform.getBearing());

--- a/src/mbgl/util/thread.cpp
+++ b/src/mbgl/util/thread.cpp
@@ -1,9 +1,13 @@
 #include <functional>
 #include <mbgl/platform/settings.hpp>
+#include <mbgl/util/logging.hpp>
 #include <mbgl/util/platform.hpp>
+#include <mbgl/util/thread.hpp>
+#include <stdexcept>
 
 namespace mbgl {
 namespace util {
+
 std::function<void()> makeThreadPrioritySetter(std::string threadType_) {
     return [threadType = std::move(threadType_)] {
         auto& settings = platform::Settings::getInstance();
@@ -15,5 +19,27 @@ std::function<void()> makeThreadPrioritySetter(std::string threadType_) {
         }
     };
 }
+
+ThreadPriorityOverrider::ThreadPriorityOverride ThreadPriorityOverrider::threadPriorityOverride =
+    ThreadPriorityOverrider::ThreadPriorityOverride::NONE;
+
+ThreadPriorityOverrider::ThreadPriorityOverrider(int threadPriorityOverride_) {
+    switch (threadPriorityOverride_) {
+        case static_cast<int>(ThreadPriorityOverride::NONE):
+            threadPriorityOverride = ThreadPriorityOverride::NONE;
+            break;
+        case static_cast<int>(ThreadPriorityOverride::FORCE_LOW):
+            Log::Warning(Event::General, "Forcing low thread priority");
+            threadPriorityOverride = ThreadPriorityOverride::FORCE_LOW;
+            break;
+        case static_cast<int>(ThreadPriorityOverride::FORCE_HIGH):
+            Log::Warning(Event::General, "Forcing high thread priority");
+            threadPriorityOverride = ThreadPriorityOverride::FORCE_HIGH;
+            break;
+        default:
+            throw std::runtime_error("Invalid thread priority override value");
+    }
+}
+
 } // namespace util
 } // namespace mbgl


### PR DESCRIPTION
for debugging and profiling purpose, we add a flag to override the default thread priority behavior by either forcing all thread to run with high or low priority. The override can be optionally passed to MapLibre using the code:
```
MapLibreMapOptions.createFromAttributes(context).apply {
    threadPriorityOverride(MapLibreMapOptions.ThreadPriorityOverride.FORCE_LOW)
}
```