### PR TITLE
Make sure we always render the next frame after puck updates

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapView.java
@@ -810,6 +810,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
                                  float iconScale,
                                  boolean cameraTracking) {
     mapRenderer.nativeSetCustomPuckState(lat, lon, bearing, iconScale, cameraTracking);
+    nativeMapView.triggerRepaint();
     if(isAutoRouteVanishing) {
       RouteID vanishingRouteID = getVanishingRouteID();
       if(vanishingRouteID.isValid() && nativeMapView != null) {


### PR DESCRIPTION
There's nothing that guarantees the rendering of the next frame when the custom puck is used unlike geojson. This is  minor change that ensures correctness