### PR TITLE
Add an option to invalidate render tiles

### DIFF
--- a/include/mbgl/renderer/tile_cache_settings.hpp
+++ b/include/mbgl/renderer/tile_cache_settings.hpp
@@ -6,12 +6,16 @@
 namespace mbgl {
 
 struct TileCacheSettings {
-    std::string source;           // The tile source ID
-    int minTiles = 0;             // The computed tile cache size is clamped between minTiles and maxTiles
-    int maxTiles = 0;             // The computed tile cache size is clamped between minTiles and maxTiles
-    int minZoom = 0;              // The minimum zoom level for the tile cache
-    int maxZoom = 32;             // The maximum zoom level for the tile cache
-    double cachedTileMaxAge = 0;  // The maximum age of cached tiles in seconds. If 0, no tiles are removed based on age
+    std::string source;          // The tile source ID
+    int minTiles = 0;            // The computed tile cache size is clamped between minTiles and maxTiles
+    int maxTiles = 0;            // The computed tile cache size is clamped between minTiles and maxTiles
+    int minZoom = 0;             // The minimum zoom level for the tile cache
+    int maxZoom = 32;            // The maximum zoom level for the tile cache
+    double cachedTileMaxAge = 0; // The maximum age of cached tiles in seconds. If 0, no tiles are removed based on age
+    double renderTileMaxAge =
+        0; // The maximum age of tiles being rendered in seconds. If 0, no render tiles are removed based on age. The
+           // same render tiles are reused when the camera is not moving. Setting a maximum age ensures short lived
+           // tiles such as rendered traffic tiles are invalidated which forces a cache request.
     bool aggressiveCache = false; // If true, tiles that are not ideal are also cached. Check update_renderables.hpp for
                                   // details about ideal tiles.
     bool skipRelayoutClear =

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -1354,6 +1354,7 @@ void NativeMapView::addTileCacheSettings(JNIEnv& env,
                                          jni::jint minZoom,
                                          jni::jint maxZoom,
                                          jni::jdouble cachedTileMaxAge,
+                                         jni::jdouble renderTileMaxAge,
                                          jni::jboolean aggressiveCache,
                                          jni::jboolean skipRelayoutClear) {
     mbgl::TileCacheSettings settings{};
@@ -1363,6 +1364,7 @@ void NativeMapView::addTileCacheSettings(JNIEnv& env,
     settings.minZoom = minZoom;
     settings.maxZoom = maxZoom;
     settings.cachedTileMaxAge = cachedTileMaxAge;
+    settings.renderTileMaxAge = renderTileMaxAge;
     settings.aggressiveCache = aggressiveCache == jni::jni_true;
     settings.skipRelayoutClear = skipRelayoutClear == jni::jni_true;
     rendererFrontend->addTileCacheSettings(settings);

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
@@ -370,6 +370,7 @@ public:
                               jni::jint,
                               jni::jint,
                               jni::jdouble,
+                              jni::jdouble,
                               jni::jboolean,
                               jni::jboolean);
 

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
@@ -843,6 +843,7 @@ final class NativeMapView implements NativeMap {
                                settings.minZoom,
                                settings.maxZoom,
                                settings.cachedTileMaxAge,
+                               settings.renderTileMaxAge,
                                settings.aggressiveCache,
                                settings.skipRelayoutClear);
   }
@@ -2001,6 +2002,7 @@ final class NativeMapView implements NativeMap {
                                                  int minZoom,
                                                  int maxZoom,
                                                  double cachedTileMaxAge,
+                                                 double renderTileMaxAge,
                                                  boolean aggressiveCache,
                                                  boolean skipRelayoutClear);
 

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/TileCacheSettings.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/TileCacheSettings.java
@@ -33,6 +33,15 @@ final public class TileCacheSettings {
     public double cachedTileMaxAge;
 
     /***
+     * The maximum age of tiles being rendered in seconds.
+     * If 0, no render tiles are removed based on age.
+     * The same render tiles are reused when the camera is not moving.
+     * Setting a maximum age ensures short lived tiles such as rendered
+     * traffic tiles are invalidated which forces a cache request.
+     */
+    public double renderTileMaxAge;
+
+    /***
      * If true, tiles that are not ideal are also cached
      * Check update_renderables.hpp for details about ideal tiles
      */

--- a/src/mbgl/renderer/tile_pyramid.hpp
+++ b/src/mbgl/renderer/tile_pyramid.hpp
@@ -92,6 +92,12 @@ private:
 
     float prevLng = 0;
 
+    // Data used to invalidate render tiles
+    using TimePoint = std::chrono::time_point<std::chrono::steady_clock>;
+    double renderTileMaxAge = 0;
+    std::vector<OverscaledTileID> previousIdealTiles;
+    TimePoint lastIdealTilesChange{};
+
     bool fadingTiles = false;
     bool cacheEnabled = true;
     bool aggressiveTileCache = false;


### PR DESCRIPTION
Render tiles (already have GPU resources and are renderable) are reused when the camera is not moving without making a cache request for these tiles. Short lived tiles (have a short http max age and http etag often expire) needs to be re downloaded.
A good example of short lived tiles are real time traffic data stored as a tile source.
Adding expiration logic to the render tiles is not straightforward. However a straightforward approach is to simply clear render tiles if they are short lived at a constant interval if the camera isn't changing (the ideal tiles remain unchanged between frames).
This PR exposes the option `TileCacheSettings::renderTileMaxAge` to the client app to set a max age for rendering tiles.