### PR TITLE
Log an error if UTF conversion fails

### DIFF
--- a/platform/default/src/mbgl/util/utf.cpp
+++ b/platform/default/src/mbgl/util/utf.cpp
@@ -1,3 +1,4 @@
+#include <mbgl/util/logging.hpp>
 #include <mbgl/util/utf.hpp>
 
 #include <locale>
@@ -7,15 +8,29 @@ namespace mbgl {
 namespace util {
 
 std::u16string convertUTF8ToUTF16(const std::string& str) {
-    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> conv;
-
-    return conv.from_bytes(str);
+    try {
+        std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> conv;
+        return conv.from_bytes(str);
+    } catch (...) {
+        Log::Error(Event::General, "Invalid UTF-8 sequence encountered during conversion to UTF-16:");
+        for (const auto& c : str) {
+            Log::Error(Event::General, std::string(" ") + c);
+        }
+        return u"";
+    }
 }
 
 std::string convertUTF16ToUTF8(const std::u16string& str) {
-    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> conv;
-
-    return conv.to_bytes(str);
+    try {
+        std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> conv;
+        return conv.to_bytes(str);
+    } catch (...) {
+        Log::Error(Event::General, "Invalid UTF-16 sequence encountered during conversion to UTF-8:");
+        for (const auto& c : str) {
+            Log::Error(Event::General, std::string(" ") + static_cast<char>(c));
+        }
+        return "";
+    }
 }
 
 } // namespace util


### PR DESCRIPTION
An error is logged an the program doesn't crash if `std::wstring_convert` throws `std::range_error`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alproton/maplibre-native/86)
<!-- Reviewable:end -->
