### PR TITLE
add a lock to layer when multiple threads call these APIs

### DIFF
--- a/platform/android/MapLibreAndroid/src/cpp/style/layers/layer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/layers/layer.cpp
@@ -59,6 +59,7 @@ std::unique_ptr<mbgl::style::Layer> Layer::releaseCoreLayer() {
 }
 
 jni::Local<jni::String> Layer::getId(jni::JNIEnv& env) {
+    auto guard = layerPtr.lock();
     auto layer = layerPtr.get();
     if (!layer) {
         return jni::Make<jni::String>(env, "");
@@ -72,6 +73,7 @@ style::Layer& Layer::get() {
 }
 
 void Layer::setProperty(jni::JNIEnv& env, const jni::String& jname, const jni::Object<>& jvalue) {
+    auto guard = layerPtr.lock();
     auto layer = layerPtr.get();
     if (!layer) {
         return;
@@ -91,6 +93,8 @@ void Layer::setFilter(jni::JNIEnv& env, const jni::Array<jni::Object<>>& jfilter
     using namespace mbgl::style;
     using namespace mbgl::style::conversion;
 
+    // Hold lock to prevent layer destruction during operation
+    auto guard = layerPtr.lock();
     auto layer = layerPtr.get();
     if (!layer) {
         return;
@@ -110,6 +114,7 @@ jni::Local<jni::Object<gson::JsonElement>> Layer::getFilter(jni::JNIEnv& env) {
     using namespace mbgl::style;
     using namespace mbgl::style::conversion;
 
+    auto guard = layerPtr.lock();
     auto layer = layerPtr.get();
     if (!layer) {
         return jni::Local<jni::Object<gson::JsonElement>>(env, nullptr);
@@ -125,6 +130,7 @@ jni::Local<jni::Object<gson::JsonElement>> Layer::getFilter(jni::JNIEnv& env) {
 }
 
 void Layer::setSourceLayer(jni::JNIEnv& env, const jni::String& sourceLayer) {
+    auto guard = layerPtr.lock();
     auto layer = layerPtr.get();
     if (!layer) {
         return;
@@ -134,6 +140,7 @@ void Layer::setSourceLayer(jni::JNIEnv& env, const jni::String& sourceLayer) {
 }
 
 jni::Local<jni::String> Layer::getSourceLayer(jni::JNIEnv& env) {
+    auto guard = layerPtr.lock();
     auto layer = layerPtr.get();
     if (!layer) {
         return jni::Make<jni::String>(env, "");
@@ -143,6 +150,7 @@ jni::Local<jni::String> Layer::getSourceLayer(jni::JNIEnv& env) {
 }
 
 jni::Local<jni::String> Layer::getSourceId(jni::JNIEnv& env) {
+    auto guard = layerPtr.lock();
     auto layer = layerPtr.get();
     if (!layer) {
         return jni::Make<jni::String>(env, "");
@@ -152,6 +160,7 @@ jni::Local<jni::String> Layer::getSourceId(jni::JNIEnv& env) {
 }
 
 jni::jfloat Layer::getMinZoom(jni::JNIEnv&) {
+    auto guard = layerPtr.lock();
     auto layer = layerPtr.get();
     if (!layer) {
         return 0.0f;
@@ -161,6 +170,7 @@ jni::jfloat Layer::getMinZoom(jni::JNIEnv&) {
 }
 
 jni::jfloat Layer::getMaxZoom(jni::JNIEnv&) {
+    auto guard = layerPtr.lock();
     auto layer = layerPtr.get();
     if (!layer) {
         return 0.0f;
@@ -170,6 +180,7 @@ jni::jfloat Layer::getMaxZoom(jni::JNIEnv&) {
 }
 
 void Layer::setMinZoom(jni::JNIEnv&, jni::jfloat zoom) {
+    auto guard = layerPtr.lock();
     auto layer = layerPtr.get();
     if (!layer) {
         return;
@@ -179,6 +190,7 @@ void Layer::setMinZoom(jni::JNIEnv&, jni::jfloat zoom) {
 }
 
 void Layer::setMaxZoom(jni::JNIEnv&, jni::jfloat zoom) {
+    auto guard = layerPtr.lock();
     auto layer = layerPtr.get();
     if (!layer) {
         return;
@@ -190,6 +202,7 @@ void Layer::setMaxZoom(jni::JNIEnv&, jni::jfloat zoom) {
 jni::Local<jni::Object<>> Layer::getVisibility(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
 
+    auto guard = layerPtr.lock();
     auto layer = layerPtr.get();
     if (!layer) {
         return std::move(*convert<jni::Local<jni::Object<>>>(env, style::VisibilityType::None));

--- a/platform/android/MapLibreAndroid/src/cpp/style/layers/layer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/layers/layer.cpp
@@ -100,6 +100,10 @@ void Layer::setFilter(jni::JNIEnv& env, const jni::Array<jni::Object<>>& jfilter
         return;
     }
 
+    if (!jfilter) {
+        return;
+    }
+
     Error error;
     std::optional<Filter> converted = convert<Filter>(Value(env, jfilter), error);
     if (!converted) {


### PR DESCRIPTION
https://rivianvwgroup.atlassian.net/browse/SYSINT-391690

The layer pointer is a mapbox implementation of weak pointer. In the documentation for WeakPtrBase::get(), it explicitly mentions to lock() in a multi threaded environment. The code calls layerPtr.get() without holding a lock. If the layer is destroyed on another thread after get() but before layer->setFilter(), this could lead to undefined behavior.

Speaking to alex mousavi, it may be that all this time this method was called from main thread but somehow now nav maybe calling this from other threads. Its not a bad idea to lock eitherway but I also see this weak pointer used in other methods as well and have followed the same reasoning for other methods that use the weakpointer access to the layer.
