### PR TITLE
Fix for the broken MLN render in nav app

### DIFF
--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -211,7 +211,10 @@ void NativeMapView::onWillStartRenderingFrame() {
 
     // Use cached global reference instead of javaPeer.get() to avoid blocking on JVM locks
     // This prevents ANR during SCREEN_OFF when GC may be holding locks
-    if (!cachedJavaPeer) return;
+    if (!cachedJavaPeer) {
+        mbgl::Log::Warning(mbgl::Event::General, "onWillStartRenderingFrame: cachedJavaPeer is null");
+        return;
+    }
 
     android::UniqueEnv _env = android::AttachEnv();
     static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
@@ -222,42 +225,51 @@ void NativeMapView::onWillStartRenderingFrame() {
 void NativeMapView::onDidFinishRenderingFrame(MapObserver::RenderFrameStatus status) {
     assert(vm != nullptr);
 
+    // Use cached global reference instead of javaPeer.get() to avoid blocking on JVM locks
+    if (!cachedJavaPeer) {
+        mbgl::Log::Warning(mbgl::Event::General, "onDidFinishRenderingFrame: cachedJavaPeer is null");
+        return;
+    }
+
     android::UniqueEnv _env = android::AttachEnv();
     static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
     static auto onDidFinishRenderingFrame = javaClass.GetMethod<void(jboolean, jdouble, jdouble)>(
         *_env, "onDidFinishRenderingFrame");
-    auto weakReference = javaPeer.get(*_env);
-    if (weakReference) {
-        weakReference.Call(*_env,
-                           onDidFinishRenderingFrame,
-                           (jboolean)(status.mode != MapObserver::RenderMode::Partial),
-                           (jdouble)status.frameEncodingTime,
-                           (jdouble)status.frameRenderingTime);
-    }
+    cachedJavaPeer.Call(*_env,
+                        onDidFinishRenderingFrame,
+                        (jboolean)(status.mode != MapObserver::RenderMode::Partial),
+                        (jdouble)status.frameEncodingTime,
+                        (jdouble)status.frameRenderingTime);
 }
 
 void NativeMapView::onWillStartRenderingMap() {
     assert(vm != nullptr);
 
+    // Use cached global reference instead of javaPeer.get() to avoid blocking on JVM locks
+    if (!cachedJavaPeer) {
+        mbgl::Log::Warning(mbgl::Event::General, "onWillStartRenderingMap: cachedJavaPeer is null");
+        return;
+    }
+
     android::UniqueEnv _env = android::AttachEnv();
     static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
     static auto onWillStartRenderingMap = javaClass.GetMethod<void()>(*_env, "onWillStartRenderingMap");
-    auto weakReference = javaPeer.get(*_env);
-    if (weakReference) {
-        weakReference.Call(*_env, onWillStartRenderingMap);
-    }
+    cachedJavaPeer.Call(*_env, onWillStartRenderingMap);
 }
 
 void NativeMapView::onDidFinishRenderingMap(MapObserver::RenderMode mode) {
     assert(vm != nullptr);
 
+    // Use cached global reference instead of javaPeer.get() to avoid blocking on JVM locks
+    if (!cachedJavaPeer) {
+        mbgl::Log::Warning(mbgl::Event::General, "onDidFinishRenderingMap: cachedJavaPeer is null");
+        return;
+    }
+
     android::UniqueEnv _env = android::AttachEnv();
     static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
     static auto onDidFinishRenderingMap = javaClass.GetMethod<void(jboolean)>(*_env, "onDidFinishRenderingMap");
-    auto weakReference = javaPeer.get(*_env);
-    if (weakReference) {
-        weakReference.Call(*_env, onDidFinishRenderingMap, (jboolean)(mode != MapObserver::RenderMode::Partial));
-    }
+    cachedJavaPeer.Call(*_env, onDidFinishRenderingMap, (jboolean)(mode != MapObserver::RenderMode::Partial));
 }
 
 void NativeMapView::onDidBecomeIdle() {

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -99,6 +99,11 @@ NativeMapView::NativeMapView(jni::JNIEnv& _env,
         return;
     }
 
+    // Cache a global reference to the Java peer to avoid blocking javaPeer.get() calls
+    // on every frame. This prevents ANR during SCREEN_OFF when GC may be holding JVM locks.
+    // This is safe because this object is created on the main thread and lives until destroy().
+    cachedJavaPeer = jni::NewGlobal(_env, _obj);
+
     // Create a renderer frontend
     rendererFrontend = AndroidRendererFrontend::create(_env, jMapRenderer);
     routeMgr = std::make_unique<mbgl::route::RouteManager>();
@@ -125,6 +130,7 @@ NativeMapView::NativeMapView(jni::JNIEnv& _env,
  */
 NativeMapView::~NativeMapView() {
     map.reset();
+    cachedJavaPeer.reset(); // Clear the cached global reference
     vm = nullptr;
 }
 
@@ -203,13 +209,14 @@ void NativeMapView::onDidFailLoadingMap(MapLoadError, const std::string& error) 
 void NativeMapView::onWillStartRenderingFrame() {
     assert(vm != nullptr);
 
+    // Use cached global reference instead of javaPeer.get() to avoid blocking on JVM locks
+    // This prevents ANR during SCREEN_OFF when GC may be holding locks
+    if (!cachedJavaPeer) return;
+
     android::UniqueEnv _env = android::AttachEnv();
     static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
     static auto onWillStartRenderingFrame = javaClass.GetMethod<void()>(*_env, "onWillStartRenderingFrame");
-    auto weakReference = javaPeer.get(*_env);
-    if (weakReference) {
-        weakReference.Call(*_env, onWillStartRenderingFrame);
-    }
+    cachedJavaPeer.Call(*_env, onWillStartRenderingFrame);
 }
 
 void NativeMapView::onDidFinishRenderingFrame(MapObserver::RenderFrameStatus status) {

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -200,6 +200,59 @@ void NativeMapView::onDidFailLoadingMap(MapLoadError, const std::string& error) 
     }
 }
 
+void NativeMapView::onWillStartRenderingFrame() {
+    assert(vm != nullptr);
+
+    android::UniqueEnv _env = android::AttachEnv();
+    static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
+    static auto onWillStartRenderingFrame = javaClass.GetMethod<void()>(*_env, "onWillStartRenderingFrame");
+    auto weakReference = javaPeer.get(*_env);
+    if (weakReference) {
+        weakReference.Call(*_env, onWillStartRenderingFrame);
+    }
+}
+
+void NativeMapView::onDidFinishRenderingFrame(MapObserver::RenderFrameStatus status) {
+    assert(vm != nullptr);
+
+    android::UniqueEnv _env = android::AttachEnv();
+    static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
+    static auto onDidFinishRenderingFrame = javaClass.GetMethod<void(jboolean, jdouble, jdouble)>(
+        *_env, "onDidFinishRenderingFrame");
+    auto weakReference = javaPeer.get(*_env);
+    if (weakReference) {
+        weakReference.Call(*_env,
+                           onDidFinishRenderingFrame,
+                           (jboolean)(status.mode != MapObserver::RenderMode::Partial),
+                           (jdouble)status.frameEncodingTime,
+                           (jdouble)status.frameRenderingTime);
+    }
+}
+
+void NativeMapView::onWillStartRenderingMap() {
+    assert(vm != nullptr);
+
+    android::UniqueEnv _env = android::AttachEnv();
+    static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
+    static auto onWillStartRenderingMap = javaClass.GetMethod<void()>(*_env, "onWillStartRenderingMap");
+    auto weakReference = javaPeer.get(*_env);
+    if (weakReference) {
+        weakReference.Call(*_env, onWillStartRenderingMap);
+    }
+}
+
+void NativeMapView::onDidFinishRenderingMap(MapObserver::RenderMode mode) {
+    assert(vm != nullptr);
+
+    android::UniqueEnv _env = android::AttachEnv();
+    static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
+    static auto onDidFinishRenderingMap = javaClass.GetMethod<void(jboolean)>(*_env, "onDidFinishRenderingMap");
+    auto weakReference = javaPeer.get(*_env);
+    if (weakReference) {
+        weakReference.Call(*_env, onDidFinishRenderingMap, (jboolean)(mode != MapObserver::RenderMode::Partial));
+    }
+}
+
 void NativeMapView::onDidBecomeIdle() {
     assert(vm != nullptr);
 

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
@@ -452,6 +452,10 @@ private:
 
     JavaVM* vm = nullptr;
     jni::WeakReference<jni::Object<NativeMapView>> javaPeer;
+    
+    // Cached global reference to avoid blocking javaPeer.get() calls on every frame
+    // This prevents ANR during SCREEN_OFF when GC may be holding JVM locks
+    jni::Global<jni::Object<NativeMapView>> cachedJavaPeer;
 
     MapRenderer& mapRenderer;
 

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
@@ -64,6 +64,10 @@ public:
     void onWillStartLoadingMap() override;
     void onDidFinishLoadingMap() override;
     void onDidFailLoadingMap(MapLoadError, const std::string&) override;
+    void onWillStartRenderingFrame() override;
+    void onDidFinishRenderingFrame(MapObserver::RenderFrameStatus) override;
+    void onWillStartRenderingMap() override;
+    void onDidFinishRenderingMap(MapObserver::RenderMode) override;
     void onDidBecomeIdle() override;
     void onDidFinishLoadingStyle() override;
     void onSourceChanged(mbgl::style::Source&) override;


### PR DESCRIPTION
This PR returns back the removed functions that are infact  being used within MLN and needed for nav. The getPeer method is a blocking call and when the main thread is busy, the getPeer called from the render thread can cause contention waiting and hence causing ANR. I have cached the NativeMapView and using it only for onWillStartRenderingFrame since that is what is indicated in the ANR watch dog log. If we need it for other functions, we can expand to them if we find them listed by the ANR watch dog.