### PR TITLE
added usage of cached java peer for high frequency functions

### DIFF
--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -138,11 +138,10 @@ void NativeMapView::onCameraWillChange(MapObserver::CameraChangeMode mode) {
     assert(vm != nullptr);
 
     android::UniqueEnv _env = android::AttachEnv();
-    static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
-    static auto onCameraWillChange = javaClass.GetMethod<void(jboolean)>(*_env, "onCameraWillChange");
-    auto weakReference = javaPeer.get(*_env);
-    if (weakReference) {
-        weakReference.Call(*_env, onCameraWillChange, (jboolean)(mode != MapObserver::CameraChangeMode::Immediate));
+    if (cachedJavaPeer) {
+        static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
+        static auto onCameraWillChange = javaClass.GetMethod<void(jboolean)>(*_env, "onCameraWillChange");
+        cachedJavaPeer.Call(*_env, onCameraWillChange, (jboolean)(mode != MapObserver::CameraChangeMode::Immediate));
     }
 }
 
@@ -150,11 +149,10 @@ void NativeMapView::onCameraIsChanging() {
     assert(vm != nullptr);
 
     android::UniqueEnv _env = android::AttachEnv();
-    static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
-    static auto onCameraIsChanging = javaClass.GetMethod<void()>(*_env, "onCameraIsChanging");
-    auto weakReference = javaPeer.get(*_env);
-    if (weakReference) {
-        weakReference.Call(*_env, onCameraIsChanging);
+    if (cachedJavaPeer) {
+        static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
+        static auto onCameraIsChanging = javaClass.GetMethod<void()>(*_env, "onCameraIsChanging");
+        cachedJavaPeer.Call(*_env, onCameraIsChanging);
     }
 }
 
@@ -162,11 +160,10 @@ void NativeMapView::onCameraDidChange(MapObserver::CameraChangeMode mode) {
     assert(vm != nullptr);
 
     android::UniqueEnv _env = android::AttachEnv();
-    static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
-    static auto onCameraDidChange = javaClass.GetMethod<void(jboolean)>(*_env, "onCameraDidChange");
-    auto weakReference = javaPeer.get(*_env);
-    if (weakReference) {
-        weakReference.Call(*_env, onCameraDidChange, (jboolean)(mode != MapObserver::CameraChangeMode::Immediate));
+    if (cachedJavaPeer) {
+        static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
+        static auto onCameraDidChange = javaClass.GetMethod<void(jboolean)>(*_env, "onCameraDidChange");
+        cachedJavaPeer.Call(*_env, onCameraDidChange, (jboolean)(mode != MapObserver::CameraChangeMode::Immediate));
     }
 }
 


### PR DESCRIPTION
Looking at logs in Nav, the camera change methods are called at a high frequency either during active nav or touch interactions. Since we have tested the usage of cached peer in a couple of BBs, these next few APIs would benefit from using cached peer as well.