### PR TITLE
Fix for sysint 417788 check for corrupt render orchestrator

### DIFF
--- a/platform/android/MapLibreAndroid/src/cpp/android_renderer_frontend.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/android_renderer_frontend.cpp
@@ -176,7 +176,17 @@ void AndroidRendererFrontend::clearData() {
 }
 
 void AndroidRendererFrontend::onStyleChange() {
-    mapRenderer.actor().invoke(&Renderer::onStyleChange);
+    const uint64_t gen = mapRenderer.getRendererGeneration();
+    mapRenderer.schedule([this, gen]() {
+    if (gen != mapRenderer.getRendererGeneration()) {
+        // New renderer will get fresh style on initialization
+        Log::Debug(Event::Android, "Renderer was recreated, discarding stale message");
+        return;
+    }
+    if (auto* renderer = mapRenderer.getRenderer()) {
+        renderer->onStyleChange();
+    }
+});
 }
 
 std::vector<Feature> AndroidRendererFrontend::querySourceFeatures(const std::string& sourceID,

--- a/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
@@ -281,6 +281,14 @@ gfx::RenderingStats MapRenderer::getRenderingStats() {
     return backend->getImpl().getRenderingStats();
 }
 
+uint64_t MapRenderer::getRendererGeneration() const {
+    return rendererGeneration.load();
+}
+
+Renderer* MapRenderer::getRenderer() const {
+    return renderer.get();
+}
+
 void MapRenderer::onSurfaceCreated(JNIEnv& env, const jni::Object<AndroidSurface>& surface) {
     // Lock as the initialization can come from the main thread or the GL thread first
     {
@@ -295,6 +303,8 @@ void MapRenderer::onSurfaceCreated(JNIEnv& env, const jni::Object<AndroidSurface
         // attempt to clean them up will fail
         if (backend) backend->markContextLost();
         if (renderer) renderer->markContextLost();
+
+        ++rendererGeneration;
 
         // Reset in opposite order
         renderer.reset();

--- a/platform/android/MapLibreAndroid/src/cpp/map_renderer.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/map_renderer.hpp
@@ -98,6 +98,9 @@ public:
 
     int getLastRenderedTileCount() const noexcept;
 
+    uint64_t getRendererGeneration() const;
+    Renderer* getRenderer() const;
+
 protected:
     // Called from the GL Thread //
 
@@ -161,6 +164,7 @@ private:
     std::mutex updateMutex;
 
     std::atomic<bool> destroyed{false};
+    std::atomic<uint64_t> rendererGeneration{0};
 
     std::unique_ptr<SnapshotCallback> snapshotCallback;
 

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -880,9 +880,19 @@ bool RenderOrchestrator::isLoaded() const {
 void RenderOrchestrator::onStyleChange() {
     MLN_TRACE_FUNC();
 
-    for (auto& source : renderSources) {
-        source.second->onStyleChange();
+    // Guard against use-after-free when style change message is processed
+    // after the orchestrator has been marked for destruction
+    if (contextLost) {
+        return;
     }
+
+    for (auto& source : renderSources) {
+        if(source.second) {
+            source.second->onStyleChange();
+        }
+    }
+
+    Log::Info(Event::Style, "MaplibreNative RenderOrchestrator::OnStyleChange() completed");
 }
 
 void RenderOrchestrator::clearData() {


### PR DESCRIPTION
We see a crash that I suspect happens at a very low frequency. Basically a style change has occurred and the onStyleChange message is asynchronously queued. It captures the this pointer which is &Renderer::onStyleChange => impl->orchestrator.onStyleChange()

The hunch here is that the renderer and the orchestrator are destroyed and by the time message is received and the contextLost variable is set to true for the old render orchestrator.  The orchestrator is freed and overwritten. So lets not propogate if context is lost.

other check is just a null pointer check if for some reason there is a valid source key but not valid rendersource. Just being defensive here.

//update
After looking at the code in RivianICsystem, there is more clarity. The sequence leading to crash is:
* Main Thread - style change initiated
* Main Thread - onStyleChanged is queue via mailbox with reference to Renderer A
* GL thread - egl context is lost- STR
* GL thread - Renderer A is disposed and Renderer B is created
* GL thread - too late , we just got the style change message referencing Renderer A
crash

In this PR, the solution is to track the generation of renderer. The generation counter is incremented before the old renderer is destroyed. The style change handler captures the generation synchronously and validates on gl thread.

Its ok if we don't honor style change when a new surface is constructed because when a new surface is constructed, it uses the latest style that is set in native map view.
