### PR TITLE
add support for http request timing for tiles

### DIFF
--- a/platform/android/MapLibreAndroid/src/cpp/http_file_source.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/http_file_source.cpp
@@ -12,6 +12,10 @@
 #include <mbgl/util/string.hpp>
 #include <mbgl/util/util.hpp>
 
+#include <algorithm>
+#include <atomic>
+#include <vector>
+
 #include <jni/jni.hpp>
 #include "attach_env.hpp"
 
@@ -36,6 +40,62 @@ private:
     ClientOptions clientOptions;
 };
 
+// Log level enum — ordinal values must match Java HttpRequestLogLevel
+enum class HTTPRequestLogLevel : int {
+    Verbose = 0,
+    Stats = 1
+};
+
+struct HTTPRequestLogOptions {
+    HTTPRequestLogLevel level = HTTPRequestLogLevel::Stats;
+    Seconds statsDuration{0};
+};
+
+struct HTTPRequestStats {
+    TimePoint windowStart = Clock::now();
+    uint32_t totalRequests = 0;
+    uint32_t successfulRequests = 0;
+    uint32_t failedRequests = 0;
+    std::vector<int64_t> successElapsedMs;
+
+    void reset() {
+        windowStart = Clock::now();
+        totalRequests = 0;
+        successfulRequests = 0;
+        failedRequests = 0;
+        successElapsedMs.clear();
+    }
+
+    void logAndReset(Seconds windowDuration) {
+        if (totalRequests == 0) {
+            reset();
+            return;
+        }
+
+        int64_t minMs = 0, maxMs = 0, medianMs = 0;
+        if (!successElapsedMs.empty()) {
+            std::sort(successElapsedMs.begin(), successElapsedMs.end());
+            minMs = successElapsedMs.front();
+            maxMs = successElapsedMs.back();
+            size_t n = successElapsedMs.size();
+            medianMs = (n % 2 == 0)
+                ? (successElapsedMs[n / 2 - 1] + successElapsedMs[n / 2]) / 2
+                : successElapsedMs[n / 2];
+        }
+
+        Log::Info(Event::HttpRequest,
+                  "Tile download stats (" + util::toString(windowDuration.count()) + "s window):"
+                  " Total=" + util::toString(totalRequests) +
+                  " Success=" + util::toString(successfulRequests) +
+                  " Failed=" + util::toString(failedRequests) +
+                  " Min=" + util::toString(minMs) + "ms" +
+                  " Max=" + util::toString(maxMs) + "ms" +
+                  " Median=" + util::toString(medianMs) + "ms");
+
+        reset();
+    }
+};
+
 class HTTPRequest : public AsyncRequest {
 public:
     static constexpr auto Name() { return "org/maplibre/android/http/NativeHttpRequest"; };
@@ -54,11 +114,15 @@ public:
                     const jni::String& xRateLimitReset,
                     const jni::Array<jni::jbyte>& body);
 
-    static bool timingLogsEnabled;
+    static std::atomic<bool> timingLogsEnabled;
+    static HTTPRequestLogOptions logOptions;
+    static HTTPRequestStats stats;
 
     jni::Global<jni::Object<HTTPRequest>> javaRequest;
 
 private:
+    void recordTileStats(int64_t elapsedMs, bool success);
+
     Resource resource;
     FileSource::Callback callback;
     Response response;
@@ -83,12 +147,18 @@ class HttpRequestUtil {
 public:
     static constexpr auto Name() { return "org/maplibre/android/module/http/HttpRequestUtil"; }
 
-    static void nativeSetTimingLogsEnabled(jni::JNIEnv&, const jni::Class<HttpRequestUtil>&, jni::jboolean enabled) {
-        HTTPRequest::timingLogsEnabled = enabled;
+    static void nativeSetTimingLogsEnabled(jni::JNIEnv&, const jni::Class<HttpRequestUtil>&,
+                                           jni::jboolean enabled) {
+        HTTPRequest::timingLogsEnabled.store(enabled, std::memory_order_relaxed);
     }
 
-    static jni::jboolean nativeIsTimingLogsEnabled(jni::JNIEnv&, const jni::Class<HttpRequestUtil>&) {
-        return HTTPRequest::timingLogsEnabled;
+    static void nativeSetHttpRequestLogOptions(jni::JNIEnv&, const jni::Class<HttpRequestUtil>&,
+                                               jni::jint level, jni::jlong durationSeconds) {
+        HTTPRequestLogOptions opts;
+        opts.level = static_cast<HTTPRequestLogLevel>(level);
+        opts.statsDuration = Seconds(durationSeconds);
+        HTTPRequest::logOptions = opts;
+        HTTPRequest::stats.reset();
     }
 };
 
@@ -110,8 +180,8 @@ void RegisterNativeHTTPRequest(jni::JNIEnv& env) {
         *httpRequestUtilClass,
         jni::MakeNativeMethod<decltype(&HttpRequestUtil::nativeSetTimingLogsEnabled),
                               &HttpRequestUtil::nativeSetTimingLogsEnabled>("nativeSetTimingLogsEnabled"),
-        jni::MakeNativeMethod<decltype(&HttpRequestUtil::nativeIsTimingLogsEnabled),
-                              &HttpRequestUtil::nativeIsTimingLogsEnabled>("nativeIsTimingLogsEnabled"));
+        jni::MakeNativeMethod<decltype(&HttpRequestUtil::nativeSetHttpRequestLogOptions),
+                              &HttpRequestUtil::nativeSetHttpRequestLogOptions>("nativeSetHttpRequestLogOptions"));
 }
 
 } // namespace android
@@ -170,14 +240,25 @@ void HTTPRequest::onResponse(jni::JNIEnv& env,
                              const jni::String& jRetryAfter,
                              const jni::String& jXRateLimitReset,
                              const jni::Array<jni::jbyte>& body) {
-    if (timingLogsEnabled && resource.kind == Resource::Kind::Tile) {
+    if (resource.kind == Resource::Kind::Tile && timingLogsEnabled) {
         auto elapsed = std::chrono::duration_cast<Milliseconds>(Clock::now() - requestStartTime);
-        size_t dataSize = body ? body.Length(env) : 0;
-        Log::Info(Event::HttpRequest,
-                  "Tile download completed: URL=" + resource.url +
-                  " Status=" + util::toString(code) +
-                  " Size=" + util::toString(dataSize) + "B" +
-                  " Elapsed=" + util::toString(elapsed.count()) + "ms");
+        // A tile download is considered successful when the server returned
+        // either a 2xx (OK, No Content, Partial Content, etc.) or 304
+        // (Not Modified — cached data is still valid). Server errors (4xx, 5xx)
+        // are not counted as successful since no usable tile data was obtained.
+        // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status
+        bool success = ((code >= 200 && code < 300) || code == 304);
+
+        if (logOptions.level == HTTPRequestLogLevel::Verbose) {
+            size_t dataSize = body ? body.Length(env) : 0;
+            Log::Info(Event::HttpRequest,
+                      "Tile download completed: URL=" + resource.url +
+                      " Status=" + util::toString(code) +
+                      " Size=" + util::toString(dataSize) + "B" +
+                      " Elapsed=" + util::toString(elapsed.count()) + "ms");
+        } else if (logOptions.level == HTTPRequestLogLevel::Stats) {
+            recordTileStats(elapsed.count(), success);
+        }
     }
 
     using Error = Response::Error;
@@ -239,12 +320,17 @@ void HTTPRequest::onResponse(jni::JNIEnv& env,
 void HTTPRequest::onFailure(jni::JNIEnv& env, int type, const jni::String& message) {
     std::string messageStr = jni::Make<std::string>(env, message);
 
-    if (timingLogsEnabled && resource.kind == Resource::Kind::Tile) {
+    if (resource.kind == Resource::Kind::Tile && timingLogsEnabled) {
         auto elapsed = std::chrono::duration_cast<Milliseconds>(Clock::now() - requestStartTime);
-        Log::Warning(Event::HttpRequest,
-                     "Tile download failed: URL=" + resource.url +
-                     " Error=" + messageStr +
-                     " Elapsed=" + util::toString(elapsed.count()) + "ms");
+
+        if (logOptions.level == HTTPRequestLogLevel::Verbose) {
+            Log::Warning(Event::HttpRequest,
+                         "Tile download failed: URL=" + resource.url +
+                         " Error=" + messageStr +
+                         " Elapsed=" + util::toString(elapsed.count()) + "ms");
+        } else if (logOptions.level == HTTPRequestLogLevel::Stats) {
+            recordTileStats(elapsed.count(), false);
+        }
     }
 
     using Error = Response::Error;
@@ -263,7 +349,24 @@ void HTTPRequest::onFailure(jni::JNIEnv& env, int type, const jni::String& messa
     async.send();
 }
 
-bool HTTPRequest::timingLogsEnabled = false;
+std::atomic<bool> HTTPRequest::timingLogsEnabled{false};
+HTTPRequestLogOptions HTTPRequest::logOptions;
+HTTPRequestStats HTTPRequest::stats;
+
+void HTTPRequest::recordTileStats(int64_t elapsedMs, bool success) {
+    stats.totalRequests++;
+    if (success) {
+        stats.successfulRequests++;
+        stats.successElapsedMs.push_back(elapsedMs);
+    } else {
+        stats.failedRequests++;
+    }
+
+    auto elapsed = std::chrono::duration_cast<Seconds>(Clock::now() - stats.windowStart);
+    if (elapsed >= logOptions.statsDuration) {
+        stats.logAndReset(logOptions.statsDuration);
+    }
+}
 
 HTTPFileSource::HTTPFileSource(const ResourceOptions& resourceOptions, const ClientOptions& clientOptions)
     : impl(std::make_unique<Impl>(resourceOptions.clone(), clientOptions.clone())) {}

--- a/platform/android/MapLibreAndroid/src/cpp/http_file_source.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/http_file_source.cpp
@@ -3,6 +3,7 @@
 #include <mbgl/storage/resource_options.hpp>
 #include <mbgl/storage/response.hpp>
 #include <mbgl/util/client_options.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/logging.hpp>
 
 #include <mbgl/util/async_request.hpp>
@@ -53,12 +54,15 @@ public:
                     const jni::String& xRateLimitReset,
                     const jni::Array<jni::jbyte>& body);
 
+    static bool timingLogsEnabled;
+
     jni::Global<jni::Object<HTTPRequest>> javaRequest;
 
 private:
     Resource resource;
     FileSource::Callback callback;
     Response response;
+    TimePoint requestStartTime;
 
     util::AsyncTask async{[this] {
         // Calling `callback` may result in deleting `this`. Copy data to temporaries first.
@@ -74,6 +78,20 @@ private:
 
 namespace android {
 
+// JNI bridge for HttpRequestUtil static native methods
+class HttpRequestUtil {
+public:
+    static constexpr auto Name() { return "org/maplibre/android/module/http/HttpRequestUtil"; }
+
+    static void nativeSetTimingLogsEnabled(jni::JNIEnv&, const jni::Class<HttpRequestUtil>&, jni::jboolean enabled) {
+        HTTPRequest::timingLogsEnabled = enabled;
+    }
+
+    static jni::jboolean nativeIsTimingLogsEnabled(jni::JNIEnv&, const jni::Class<HttpRequestUtil>&) {
+        return HTTPRequest::timingLogsEnabled;
+    }
+};
+
 void RegisterNativeHTTPRequest(jni::JNIEnv& env) {
     static auto& javaClass = jni::Class<HTTPRequest>::Singleton(env);
 
@@ -84,13 +102,24 @@ void RegisterNativeHTTPRequest(jni::JNIEnv& env) {
                                          "nativePtr",
                                          METHOD(&HTTPRequest::onFailure, "nativeOnFailure"),
                                          METHOD(&HTTPRequest::onResponse, "nativeOnResponse"));
+
+    // Register static native methods on HttpRequestUtil
+    static auto& httpRequestUtilClass = jni::Class<HttpRequestUtil>::Singleton(env);
+    jni::RegisterNatives(
+        env,
+        *httpRequestUtilClass,
+        jni::MakeNativeMethod<decltype(&HttpRequestUtil::nativeSetTimingLogsEnabled),
+                              &HttpRequestUtil::nativeSetTimingLogsEnabled>("nativeSetTimingLogsEnabled"),
+        jni::MakeNativeMethod<decltype(&HttpRequestUtil::nativeIsTimingLogsEnabled),
+                              &HttpRequestUtil::nativeIsTimingLogsEnabled>("nativeIsTimingLogsEnabled"));
 }
 
 } // namespace android
 
 HTTPRequest::HTTPRequest(jni::JNIEnv& env, const Resource& resource_, FileSource::Callback callback_)
     : resource(resource_),
-      callback(callback_) {
+      callback(callback_),
+      requestStartTime(Clock::now()) {
     std::string dataRangeStr;
     std::string etagStr;
     std::string modifiedStr;
@@ -141,6 +170,16 @@ void HTTPRequest::onResponse(jni::JNIEnv& env,
                              const jni::String& jRetryAfter,
                              const jni::String& jXRateLimitReset,
                              const jni::Array<jni::jbyte>& body) {
+    if (timingLogsEnabled && resource.kind == Resource::Kind::Tile) {
+        auto elapsed = std::chrono::duration_cast<Milliseconds>(Clock::now() - requestStartTime);
+        size_t dataSize = body ? body.Length(env) : 0;
+        Log::Info(Event::HttpRequest,
+                  "Tile download completed: URL=" + resource.url +
+                  " Status=" + util::toString(code) +
+                  " Size=" + util::toString(dataSize) + "B" +
+                  " Elapsed=" + util::toString(elapsed.count()) + "ms");
+    }
+
     using Error = Response::Error;
 
     if (etag) {
@@ -200,6 +239,14 @@ void HTTPRequest::onResponse(jni::JNIEnv& env,
 void HTTPRequest::onFailure(jni::JNIEnv& env, int type, const jni::String& message) {
     std::string messageStr = jni::Make<std::string>(env, message);
 
+    if (timingLogsEnabled && resource.kind == Resource::Kind::Tile) {
+        auto elapsed = std::chrono::duration_cast<Milliseconds>(Clock::now() - requestStartTime);
+        Log::Warning(Event::HttpRequest,
+                     "Tile download failed: URL=" + resource.url +
+                     " Error=" + messageStr +
+                     " Elapsed=" + util::toString(elapsed.count()) + "ms");
+    }
+
     using Error = Response::Error;
 
     switch (type) {
@@ -215,6 +262,8 @@ void HTTPRequest::onFailure(jni::JNIEnv& env, int type, const jni::String& messa
 
     async.send();
 }
+
+bool HTTPRequest::timingLogsEnabled = false;
 
 HTTPFileSource::HTTPFileSource(const ResourceOptions& resourceOptions, const ClientOptions& clientOptions)
     : impl(std::make_unique<Impl>(resourceOptions.clone(), clientOptions.clone())) {}

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
@@ -13,6 +13,8 @@ import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.maplibre.android.module.http.HttpRequestLogLevel;
+import org.maplibre.android.module.http.HttpRequestLogOptions;
 import org.maplibre.android.module.http.HttpRequestUtil;
 import org.maplibre.geojson.Feature;
 import org.maplibre.geojson.Geometry;
@@ -114,6 +116,9 @@ final class NativeMapView implements NativeMap {
     this.thread = Thread.currentThread();
     this.stateCallback = stateCallback;
     nativeInitialize(this, fileSource, mapRenderer, pixelRatio, crossSourceCollisions);
+
+    HttpRequestLogOptions httpLogOptions = new HttpRequestLogOptions(HttpRequestLogLevel.VERBOSE, 5);
+    HttpRequestUtil.setHttpRequestLogOptions(httpLogOptions);
     HttpRequestUtil.setTimingLogsEnabled(true);
   }
 

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
@@ -13,6 +13,7 @@ import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.maplibre.android.module.http.HttpRequestUtil;
 import org.maplibre.geojson.Feature;
 import org.maplibre.geojson.Geometry;
 import org.maplibre.android.LibraryLoader;
@@ -113,6 +114,7 @@ final class NativeMapView implements NativeMap {
     this.thread = Thread.currentThread();
     this.stateCallback = stateCallback;
     nativeInitialize(this, fileSource, mapRenderer, pixelRatio, crossSourceCollisions);
+    HttpRequestUtil.setTimingLogsEnabled(true);
   }
 
   //

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/module/http/HttpRequestLogLevel.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/module/http/HttpRequestLogLevel.java
@@ -1,0 +1,17 @@
+package org.maplibre.android.module.http;
+
+/**
+ * Controls the granularity of native HTTP tile request logging.
+ */
+public enum HttpRequestLogLevel {
+  /**
+   * Log the elapsed time and details for every individual tile download.
+   */
+  VERBOSE,
+
+  /**
+   * Log aggregate statistics (total, success, failed counts and min/max/median
+   * elapsed times) over a configurable duration window.
+   */
+  STATS
+}

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/module/http/HttpRequestLogOptions.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/module/http/HttpRequestLogOptions.java
@@ -1,0 +1,58 @@
+package org.maplibre.android.module.http;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Configuration options for native HTTP tile request logging.
+ *
+ * <p>Use with {@link HttpRequestUtil#setHttpRequestLogOptions(HttpRequestLogOptions)}
+ * to control what gets logged.</p>
+ *
+ * <ul>
+ *   <li>{@link HttpRequestLogLevel#VERBOSE} — logs every individual tile download
+ *       (elapsed time, URL, status, size). The {@code durationSeconds} field is ignored.</li>
+ *   <li>{@link HttpRequestLogLevel#STATS} — accumulates tile download statistics and
+ *       logs a summary (total, success, failed counts and min/max/median elapsed times)
+ *       every {@code durationSeconds} seconds.</li>
+ * </ul>
+ */
+public class HttpRequestLogOptions {
+
+  @NonNull
+  private final HttpRequestLogLevel level;
+  private final long durationSeconds;
+
+  /**
+   * Create log options.
+   *
+   * @param level           the logging granularity
+   * @param durationSeconds the stats window duration in seconds. Only used when
+   *                        level is {@link HttpRequestLogLevel#STATS}; ignored for VERBOSE.
+   *                        Must be at least 1 when using STATS.
+   */
+  public HttpRequestLogOptions(@NonNull HttpRequestLogLevel level, long durationSeconds) {
+    this.level = level;
+    this.durationSeconds = durationSeconds;
+  }
+
+  /**
+   * Convenience constructor for {@link HttpRequestLogLevel#VERBOSE} mode.
+   *
+   * @param level the logging granularity
+   */
+  public HttpRequestLogOptions(@NonNull HttpRequestLogLevel level) {
+    this(level, 0);
+  }
+
+  @NonNull
+  public HttpRequestLogLevel getLevel() {
+    return level;
+  }
+
+  /**
+   * @return the stats window duration in seconds
+   */
+  public long getDurationSeconds() {
+    return durationSeconds;
+  }
+}

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/module/http/HttpRequestUtil.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/module/http/HttpRequestUtil.java
@@ -53,33 +53,41 @@ public class HttpRequestUtil {
   }
 
   /**
-   * Enable or disable logging of elapsed time for native HTTP tile requests.
-   * When enabled, the native layer logs the round-trip duration for each tile
-   * download at Info severity, or Warning severity on failure.
+   * Enable or disable native HTTP tile request timing logs.
    * <p>
-   * Default value is false. This configuration will outlast the lifecycle of the Map.
+   * When enabled, every individual tile download is logged with its URL, HTTP status,
+   * response size and elapsed time (equivalent to {@link HttpRequestLogLevel#VERBOSE}).
+   * When disabled, native tile request logging is turned off.
+   * </p>
+   * <p>
+   * This configuration will outlast the lifecycle of the Map.
    * </p>
    *
-   * @param enabled True will enable timing logs, false will disable
+   * @param enabled true to enable per-tile timing logs, false to disable
    */
   public static void setTimingLogsEnabled(boolean enabled) {
     nativeSetTimingLogsEnabled(enabled);
   }
 
   /**
-   * Returns whether native HTTP tile request timing logs are enabled.
+   * Configure native HTTP tile request logging.
+   * <p>
+   * This configuration will outlast the lifecycle of the Map.
+   * </p>
    *
-   * @return True if timing logs are enabled, false otherwise
+   * @param options the log options
+   * @see HttpRequestLogOptions
+   * @see HttpRequestLogLevel
    */
-  public static boolean isTimingLogsEnabled() {
-    return nativeIsTimingLogsEnabled();
+  public static void setHttpRequestLogOptions(@NonNull HttpRequestLogOptions options) {
+    nativeSetHttpRequestLogOptions(options.getLevel().ordinal(), options.getDurationSeconds());
   }
 
   @Keep
   private static native void nativeSetTimingLogsEnabled(boolean enabled);
 
   @Keep
-  private static native boolean nativeIsTimingLogsEnabled();
+  private static native void nativeSetHttpRequestLogOptions(int level, long durationSeconds);
 
   @NonNull
   static String toHumanReadableAscii(String s) {

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/module/http/HttpRequestUtil.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/module/http/HttpRequestUtil.java
@@ -1,5 +1,6 @@
 package org.maplibre.android.module.http;
 
+import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -50,6 +51,35 @@ public class HttpRequestUtil {
   public static void setOkHttpClient(@Nullable Call.Factory client) {
     HttpRequestImpl.setOkHttpClient(client);
   }
+
+  /**
+   * Enable or disable logging of elapsed time for native HTTP tile requests.
+   * When enabled, the native layer logs the round-trip duration for each tile
+   * download at Info severity, or Warning severity on failure.
+   * <p>
+   * Default value is false. This configuration will outlast the lifecycle of the Map.
+   * </p>
+   *
+   * @param enabled True will enable timing logs, false will disable
+   */
+  public static void setTimingLogsEnabled(boolean enabled) {
+    nativeSetTimingLogsEnabled(enabled);
+  }
+
+  /**
+   * Returns whether native HTTP tile request timing logs are enabled.
+   *
+   * @return True if timing logs are enabled, false otherwise
+   */
+  public static boolean isTimingLogsEnabled() {
+    return nativeIsTimingLogsEnabled();
+  }
+
+  @Keep
+  private static native void nativeSetTimingLogsEnabled(boolean enabled);
+
+  @Keep
+  private static native boolean nativeIsTimingLogsEnabled();
 
   @NonNull
   static String toHumanReadableAscii(String s) {

--- a/platform/default/src/mbgl/storage/http_file_source.cpp
+++ b/platform/default/src/mbgl/storage/http_file_source.cpp
@@ -84,6 +84,8 @@ public:
 
     void handleResult(CURLcode code);
 
+    static bool timingLogsEnabled;
+
 private:
     static size_t headerCallback(char *buffer, size_t size, size_t nmemb, void *userp);
     static size_t writeCallback(void *contents, size_t size, size_t nmemb, void *userp);
@@ -101,6 +103,8 @@ private:
 
     CURL *handle = nullptr;
     curl_slist *headers = nullptr;
+
+    TimePoint requestStartTime;
 
     char error[CURL_ERROR_SIZE] = {0};
 };
@@ -268,7 +272,8 @@ HTTPRequest::HTTPRequest(HTTPFileSource::Impl *context_, Resource resource_, Fil
     : context(context_),
       resource(std::move(resource_)),
       callback(std::move(callback_)),
-      handle(context->getHandle()) {
+      handle(context->getHandle()),
+      requestStartTime(Clock::now()) {
     if (resource.dataRange) {
         const std::string header = std::string("Range: bytes=") + std::to_string(resource.dataRange->first) +
                                    std::string("-") + std::to_string(resource.dataRange->second);
@@ -400,6 +405,24 @@ void HTTPRequest::handleResult(CURLcode code) {
         response = std::make_unique<Response>();
     }
 
+    if (timingLogsEnabled && resource.kind == Resource::Kind::Tile) {
+        auto elapsed = std::chrono::duration_cast<Milliseconds>(Clock::now() - requestStartTime);
+        long logResponseCode = 0;
+        curl_easy_getinfo(handle, CURLINFO_RESPONSE_CODE, &logResponseCode);
+        if (code != CURLE_OK) {
+            Log::Warning(Event::HttpRequest,
+                         "Tile download failed: URL=" + resource.url +
+                         " CurlError=" + std::string{curl_easy_strerror(code)} +
+                         " Elapsed=" + util::toString(elapsed.count()) + "ms");
+        } else {
+            Log::Info(Event::HttpRequest,
+                      "Tile download completed: URL=" + resource.url +
+                      " Status=" + util::toString(logResponseCode) +
+                      " Size=" + (data ? util::toString(data->size()) : "0") + "B" +
+                      " Elapsed=" + util::toString(elapsed.count()) + "ms");
+        }
+    }
+
     using Error = Response::Error;
 
     // Add human-readable error code
@@ -452,6 +475,8 @@ void HTTPRequest::handleResult(CURLcode code) {
     auto response_ = *response;
     callback_(response_);
 }
+
+bool HTTPRequest::timingLogsEnabled = false;
 
 HTTPFileSource::HTTPFileSource(const ResourceOptions &resourceOptions, const ClientOptions &clientOptions)
     : impl(std::make_unique<Impl>(resourceOptions, clientOptions)) {}

--- a/platform/default/src/mbgl/storage/http_file_source.cpp
+++ b/platform/default/src/mbgl/storage/http_file_source.cpp
@@ -15,8 +15,11 @@
 #include <curl/curl.h>
 
 #include <dlfcn.h>
+#include <algorithm>
+#include <atomic>
 #include <queue>
 #include <map>
+#include <vector>
 #include <cassert>
 #include <cstring>
 #include <cstdio>
@@ -35,6 +38,63 @@ static void handleError(CURLcode code) {
 }
 
 namespace mbgl {
+
+// Log level enum — ordinal values must match Java HttpRequestLogLevel
+enum class HTTPRequestLogLevel : int {
+    None = -1,
+    Verbose = 0,
+    Stats = 1
+};
+
+struct HTTPRequestLogOptions {
+    HTTPRequestLogLevel level = HTTPRequestLogLevel::None;
+    Seconds statsDuration{0};
+};
+
+struct HTTPRequestStats {
+    TimePoint windowStart = Clock::now();
+    uint32_t totalRequests = 0;
+    uint32_t successfulRequests = 0;
+    uint32_t failedRequests = 0;
+    std::vector<int64_t> successElapsedMs;
+
+    void reset() {
+        windowStart = Clock::now();
+        totalRequests = 0;
+        successfulRequests = 0;
+        failedRequests = 0;
+        successElapsedMs.clear();
+    }
+
+    void logAndReset(Seconds windowDuration) {
+        if (totalRequests == 0) {
+            reset();
+            return;
+        }
+
+        int64_t minMs = 0, maxMs = 0, medianMs = 0;
+        if (!successElapsedMs.empty()) {
+            std::sort(successElapsedMs.begin(), successElapsedMs.end());
+            minMs = successElapsedMs.front();
+            maxMs = successElapsedMs.back();
+            size_t n = successElapsedMs.size();
+            medianMs = (n % 2 == 0)
+                ? (successElapsedMs[n / 2 - 1] + successElapsedMs[n / 2]) / 2
+                : successElapsedMs[n / 2];
+        }
+
+        Log::Info(Event::HttpRequest,
+                  "Tile download stats (" + util::toString(windowDuration.count()) + "s window):"
+                  " Total=" + util::toString(totalRequests) +
+                  " Success=" + util::toString(successfulRequests) +
+                  " Failed=" + util::toString(failedRequests) +
+                  " Min=" + util::toString(minMs) + "ms" +
+                  " Max=" + util::toString(maxMs) + "ms" +
+                  " Median=" + util::toString(medianMs) + "ms");
+
+        reset();
+    }
+};
 
 class HTTPFileSource::Impl {
 public:
@@ -84,9 +144,13 @@ public:
 
     void handleResult(CURLcode code);
 
-    static bool timingLogsEnabled;
+    static std::atomic<bool> timingLogsEnabled;
+    static HTTPRequestLogOptions logOptions;
+    static HTTPRequestStats stats;
 
 private:
+    void recordTileStats(int64_t elapsedMs, bool success);
+
     static size_t headerCallback(char *buffer, size_t size, size_t nmemb, void *userp);
     static size_t writeCallback(void *contents, size_t size, size_t nmemb, void *userp);
 
@@ -405,21 +469,43 @@ void HTTPRequest::handleResult(CURLcode code) {
         response = std::make_unique<Response>();
     }
 
-    if (timingLogsEnabled && resource.kind == Resource::Kind::Tile) {
+    if (resource.kind == Resource::Kind::Tile
+        && timingLogsEnabled.load(std::memory_order_relaxed)
+        && logOptions.level != HTTPRequestLogLevel::None) {
         auto elapsed = std::chrono::duration_cast<Milliseconds>(Clock::now() - requestStartTime);
         long logResponseCode = 0;
         curl_easy_getinfo(handle, CURLINFO_RESPONSE_CODE, &logResponseCode);
+
         if (code != CURLE_OK) {
             Log::Warning(Event::HttpRequest,
                          "Tile download failed: URL=" + resource.url +
                          " CurlError=" + std::string{curl_easy_strerror(code)} +
                          " Elapsed=" + util::toString(elapsed.count()) + "ms");
-        } else {
-            Log::Info(Event::HttpRequest,
-                      "Tile download completed: URL=" + resource.url +
-                      " Status=" + util::toString(logResponseCode) +
-                      " Size=" + (data ? util::toString(data->size()) : "0") + "B" +
-                      " Elapsed=" + util::toString(elapsed.count()) + "ms");
+        }
+
+        // A tile download is considered successful when curl completed without
+        // a transport error AND the server returned either a 2xx (OK, No Content,
+        // Partial Content, etc.) or 304 (Not Modified — cached data is still valid).
+        // Server errors (4xx, 5xx) delivered over a healthy connection are not
+        // counted as successful since no usable tile data was obtained.
+        // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status
+        bool success = (code == CURLE_OK) && ((logResponseCode >= 200 && logResponseCode < 300) || logResponseCode == 304);
+
+        switch (logOptions.level) {
+            case HTTPRequestLogLevel::Verbose:
+                if (code == CURLE_OK) {
+                    Log::Info(Event::HttpRequest,
+                              "Tile download completed: URL=" + resource.url +
+                              " Status=" + util::toString(logResponseCode) +
+                              " Size=" + (data ? util::toString(data->size()) : "0") + "B" +
+                              " Elapsed=" + util::toString(elapsed.count()) + "ms");
+                }
+                break;
+            case HTTPRequestLogLevel::Stats:
+                recordTileStats(elapsed.count(), success);
+                break;
+            default:
+                break;
         }
     }
 
@@ -476,7 +562,24 @@ void HTTPRequest::handleResult(CURLcode code) {
     callback_(response_);
 }
 
-bool HTTPRequest::timingLogsEnabled = false;
+std::atomic<bool> HTTPRequest::timingLogsEnabled{false};
+HTTPRequestLogOptions HTTPRequest::logOptions;
+HTTPRequestStats HTTPRequest::stats;
+
+void HTTPRequest::recordTileStats(int64_t elapsedMs, bool success) {
+    stats.totalRequests++;
+    if (success) {
+        stats.successfulRequests++;
+        stats.successElapsedMs.push_back(elapsedMs);
+    } else {
+        stats.failedRequests++;
+    }
+
+    auto elapsed = std::chrono::duration_cast<Seconds>(Clock::now() - stats.windowStart);
+    if (elapsed >= logOptions.statsDuration) {
+        stats.logAndReset(logOptions.statsDuration);
+    }
+}
 
 HTTPFileSource::HTTPFileSource(const ResourceOptions &resourceOptions, const ClientOptions &clientOptions)
     : impl(std::make_unique<Impl>(resourceOptions, clientOptions)) {}


### PR DESCRIPTION
Added support for logging timings for http requests for tiles.

JNI method added to enable this from java side. Currently I have enabled this by default in native map view. We can move this to kotlin end if we want to have decision higher.

I presume to enable the timing one time when the map view is constructed and hence kept a simple bool in HTTPRequest. If we think we would need to enable/disable while the requests are in flight, then we need to add thread safety. Keeping it simple for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alproton/maplibre-native/98)
<!-- Reviewable:end -->
