### PR TITLE
fix for crash to serialize access to statas

### DIFF
--- a/platform/android/MapLibreAndroid/src/cpp/http_file_source.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/http_file_source.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <mutex>
 #include <vector>
 
 #include <jni/jni.hpp>
@@ -119,6 +120,7 @@ public:
                     const jni::Array<jni::jbyte>& body);
 
     static std::atomic<bool> timingLogsEnabled;
+    static std::mutex statsMutex;
     static HTTPRequestLogOptions logOptions;
     static HTTPRequestStats stats;
 
@@ -158,6 +160,8 @@ public:
 
     static void nativeSetHttpRequestLogOptions(jni::JNIEnv&, const jni::Class<HttpRequestUtil>&,
                                                jni::jint level, jni::jlong durationSeconds) {
+        std::lock_guard<std::mutex> lock(HTTPRequest::statsMutex);
+
         HTTPRequestLogOptions opts;
         opts.level = static_cast<HTTPRequestLogLevel>(level);
         opts.statsDuration = Seconds(durationSeconds);
@@ -354,10 +358,13 @@ void HTTPRequest::onFailure(jni::JNIEnv& env, int type, const jni::String& messa
 }
 
 std::atomic<bool> HTTPRequest::timingLogsEnabled{false};
+std::mutex HTTPRequest::statsMutex;
 HTTPRequestLogOptions HTTPRequest::logOptions;
 HTTPRequestStats HTTPRequest::stats;
 
 void HTTPRequest::recordTileStats(int64_t elapsedMs, bool success) {
+    std::lock_guard<std::mutex> lock(statsMutex);
+
     stats.totalRequests++;
     if (success) {
         stats.successfulRequests++;


### PR DESCRIPTION
The crash indicates a data race on heap memory. The HTTPRequestStats stats struct contains a std::vector<int64_t> successElapsedMs which was being accessed from multiple OkHttp callback threads simultaneously without any synchronization:

Thread A calls stats.successElapsedMs.push_back(...)
Thread B calls stats.logAndReset() which does std::sort(...) and clear()
Both threads corrupt the vector's internal state = crash

Fix was to add a std::mutex statsMutex to protect all access to stats
* Wrapped recordTileStats() body with std::lock_guard<std::mutex> - this protects the counter increments, vector push_back, and the logAndReset() call
* Wrapped nativeSetHttpRequestLogOptions() with the same mutex — this protects the stats.reset() call that happens when options change

