### PR TITLE
Switch to glsl shader 3.0 compatability

### DIFF
--- a/include/mbgl/shaders/gl/custom_dots.hpp
+++ b/include/mbgl/shaders/gl/custom_dots.hpp
@@ -8,9 +8,9 @@ namespace shaders {
 template <>
 struct ShaderSource<BuiltIn::CustomDotsProgram, gfx::Backend::Type::OpenGL> {
     static constexpr const char* name = "CustomDotsProgram";
-    static constexpr const char* vertex = R"(#version 310 es
+    static constexpr const char* vertex = R"(#version 300 es
 layout (location = 0) in vec2 pos;
-layout(location = 1) uniform vec2 size;
+uniform vec2 size;
 out mediump vec2 uv;
 void main() {
   mediump float dx = size.x;
@@ -31,12 +31,12 @@ void main() {
   uv = triangleUv[gl_VertexID];
 }
 )";
-    static constexpr const char* fragment = R"(#version 310 es
+    static constexpr const char* fragment = R"(#version 300 es
 out mediump vec4 fragColor;
 in mediump vec2 uv;
-layout(location = 2) uniform mediump vec3 innerColor;
-layout(location = 3) uniform mediump vec3 outerColor;
-layout(location = 4) uniform mediump float innerFactor;
+uniform mediump vec3 innerColor;
+uniform mediump vec3 outerColor;
+uniform mediump float innerFactor;
 void main() {
   mediump vec2 p = uv * 2.0 - vec2(1.0);
   mediump float outer = 1.0 - min(pow(dot(p, p), 4.0), 1.0);

--- a/include/mbgl/shaders/gl/custom_puck.hpp
+++ b/include/mbgl/shaders/gl/custom_puck.hpp
@@ -8,13 +8,13 @@ namespace shaders {
 template <>
 struct ShaderSource<BuiltIn::CustomPuckProgram, gfx::Backend::Type::OpenGL> {
     static constexpr const char* name = "CustomPuckProgram";
-    static constexpr const char* vertex = R"(#version 310 es
+    static constexpr const char* vertex = R"(#version 300 es
 // Since this is a temporary workaround to issue #3135, we use
 // uniform vectors for the puck quad to simplify the GL side code
-layout(location = 0) uniform vec2 v0;
-layout(location = 1) uniform vec2 v1;
-layout(location = 2) uniform vec2 v2;
-layout(location = 3) uniform vec2 v3;
+uniform vec2 v0;
+uniform vec2 v1;
+uniform vec2 v2;
+uniform vec2 v3;
 out mediump vec2 uv;
 void main() {
   vec2 pos[4] = vec2[4](v0, v1, v2, v3);
@@ -23,11 +23,11 @@ void main() {
   uv = vertex_uv[gl_VertexID];
 }
 )";
-    static constexpr const char* fragment = R"(#version 310 es
+    static constexpr const char* fragment = R"(#version 300 es
 in mediump vec2 uv;
 out mediump vec4 fragColor;
 uniform sampler2D tex;
-layout(location = 4) uniform mediump vec4 color;
+uniform mediump vec4 color;
 void main() {
   fragColor = texture(tex, uv) * color;
 }

--- a/src/mbgl/gl/custom_dots.cpp
+++ b/src/mbgl/gl/custom_dots.cpp
@@ -80,7 +80,12 @@ private:
 
 CustomDots::CustomDots(gl::Context& context_)
     : context(context_),
-      program(createShader(context_)) {}
+      program(createShader(context_)) {
+    loc_size = MBGL_CHECK_ERROR(glGetUniformLocation(program, "size"));
+    loc_innerColor = MBGL_CHECK_ERROR(glGetUniformLocation(program, "innerColor"));
+    loc_outerColor = MBGL_CHECK_ERROR(glGetUniformLocation(program, "outerColor"));
+    loc_innerFactor = MBGL_CHECK_ERROR(glGetUniformLocation(program, "innerFactor"));
+}
 
 CustomDots::~CustomDots() noexcept {
     clearVertexBufferImpl();
@@ -154,10 +159,10 @@ void CustomDots::drawImpl() {
         const auto& outer = p.options.outerColor;
         std::ptrdiff_t bufferOffset = p.vertexOffset * 2 * sizeof(float);
         MBGL_CHECK_ERROR(glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, reinterpret_cast<void*>(bufferOffset)));
-        MBGL_CHECK_ERROR(glUniform2f(1, p.iconDx, p.iconDy));
-        MBGL_CHECK_ERROR(glUniform3f(2, inner.r, inner.g, inner.b));
-        MBGL_CHECK_ERROR(glUniform3f(3, outer.r, outer.g, outer.b));
-        MBGL_CHECK_ERROR(glUniform1f(4, p.innerFactor));
+        MBGL_CHECK_ERROR(glUniform2f(loc_size, p.iconDx, p.iconDy));
+        MBGL_CHECK_ERROR(glUniform3f(loc_innerColor, inner.r, inner.g, inner.b));
+        MBGL_CHECK_ERROR(glUniform3f(loc_outerColor, outer.r, outer.g, outer.b));
+        MBGL_CHECK_ERROR(glUniform1f(loc_innerFactor, p.innerFactor));
         MBGL_CHECK_ERROR(glDrawArraysInstanced(GL_TRIANGLES, 0, 6, p.vertexCount));
     }
 }

--- a/src/mbgl/gl/custom_dots.hpp
+++ b/src/mbgl/gl/custom_dots.hpp
@@ -22,6 +22,10 @@ private:
     VertexArrayID vao = 0;
     VertexArrayID vbo = 0;
     size_t vboSize = 0;
+    GLint loc_size = -1;
+    GLint loc_innerColor = -1;
+    GLint loc_outerColor = -1;
+    GLint loc_innerFactor = -1;
 };
 
 } // namespace gl

--- a/src/mbgl/gl/custom_dots.hpp
+++ b/src/mbgl/gl/custom_dots.hpp
@@ -22,10 +22,10 @@ private:
     VertexArrayID vao = 0;
     VertexArrayID vbo = 0;
     size_t vboSize = 0;
-    GLint loc_size = -1;
-    GLint loc_innerColor = -1;
-    GLint loc_outerColor = -1;
-    GLint loc_innerFactor = -1;
+    platform::GLint loc_size = -1;
+    platform::GLint loc_innerColor = -1;
+    platform::GLint loc_outerColor = -1;
+    platform::GLint loc_innerFactor = -1;
 };
 
 } // namespace gl

--- a/src/mbgl/gl/custom_puck.cpp
+++ b/src/mbgl/gl/custom_puck.cpp
@@ -132,7 +132,13 @@ private:
 
 CustomPuck::CustomPuck(gl::Context& context_)
     : context(context_),
-      program(createPuckShader(context_)) {}
+      program(createPuckShader(context_)) {
+    loc_v0 = MBGL_CHECK_ERROR(glGetUniformLocation(program, "v0"));
+    loc_v1 = MBGL_CHECK_ERROR(glGetUniformLocation(program, "v1"));
+    loc_v2 = MBGL_CHECK_ERROR(glGetUniformLocation(program, "v2"));
+    loc_v3 = MBGL_CHECK_ERROR(glGetUniformLocation(program, "v3"));
+    loc_color = MBGL_CHECK_ERROR(glGetUniformLocation(program, "color"));
+}
 
 void CustomPuck::drawImpl(const gfx::CustomPuckSampledStyle& sampledStyle) {
     MLN_TRACE_FUNC();
@@ -197,10 +203,11 @@ void CustomPuck::draw(const gfx::CustomPuckSampledIcon& icon) const {
     assert(textures.count(icon.name) > 0);
     auto tex = textures.at(icon.name);
     MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, tex));
+    const GLint locs[4] = {loc_v0, loc_v1, loc_v2, loc_v3};
     for (int i = 0; i < 4; ++i) {
-        MBGL_CHECK_ERROR(glUniform2f(i, static_cast<float>(icon.quad[i].x), static_cast<float>(icon.quad[i].y)));
+        MBGL_CHECK_ERROR(glUniform2f(locs[i], static_cast<float>(icon.quad[i].x), static_cast<float>(icon.quad[i].y)));
     }
-    MBGL_CHECK_ERROR(glUniform4f(4, icon.color.r, icon.color.g, icon.color.b, icon.color.a));
+    MBGL_CHECK_ERROR(glUniform4f(loc_color, icon.color.r, icon.color.g, icon.color.b, icon.color.a));
     MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLE_STRIP, 0, 4));
 }
 

--- a/src/mbgl/gl/custom_puck.hpp
+++ b/src/mbgl/gl/custom_puck.hpp
@@ -25,6 +25,11 @@ private:
     UniqueProgram program;
     std::unordered_map<gfx::CustomPuckIconName, TextureID> textures;
     int storage = 0;
+    GLint loc_v0 = -1;
+    GLint loc_v1 = -1;
+    GLint loc_v2 = -1;
+    GLint loc_v3 = -1;
+    GLint loc_color = -1;
 };
 
 } // namespace gl

--- a/src/mbgl/gl/custom_puck.hpp
+++ b/src/mbgl/gl/custom_puck.hpp
@@ -25,11 +25,11 @@ private:
     UniqueProgram program;
     std::unordered_map<gfx::CustomPuckIconName, TextureID> textures;
     int storage = 0;
-    GLint loc_v0 = -1;
-    GLint loc_v1 = -1;
-    GLint loc_v2 = -1;
-    GLint loc_v3 = -1;
-    GLint loc_color = -1;
+    platform::GLint loc_v0 = -1;
+    platform::GLint loc_v1 = -1;
+    platform::GLint loc_v2 = -1;
+    platform::GLint loc_v3 = -1;
+    platform::GLint loc_color = -1;
 };
 
 } // namespace gl


### PR DESCRIPTION
We had hardcoded layout locations within the shader for the uniform variables. This is only supported in opengl ES 3.1. The rest of the shaders in MLN uses ES 3.0.

This PR refactors to querying locations of these uniform variables and setting values  to those location.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alproton/maplibre-native/103)
<!-- Reviewable:end -->
