### PR TITLE
disable hardcoded swappy

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapLibreMapOptions.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapLibreMapOptions.java
@@ -214,10 +214,6 @@ public class MapLibreMapOptions implements Parcelable {
     float pxlRatio = context.getResources().getDisplayMetrics().density;
     try {
       maplibreMapOptions.camera(new CameraPosition.Builder(typedArray).build());
-      maplibreMapOptions.useModernEGL = true;
-      maplibreMapOptions.useSwappy = true;
-      maplibreMapOptions.enableSwappyLogs = true;
-      maplibreMapOptions.useSwappyFrameMetrics = true;
 
       // deprecated
       maplibreMapOptions.apiBaseUrl(typedArray.getString(R.styleable.maplibre_MapView_maplibre_apiBaseUrl));
@@ -785,6 +781,7 @@ public class MapLibreMapOptions implements Parcelable {
   @NonNull
   public MapLibreMapOptions enableUseSwappy(boolean enable) {
     this.useSwappy = enable;
+    this.useModernEGL = enable;
     return this;
   }
 

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapView.java
@@ -124,10 +124,10 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   }
 
   @UiThread
-  public MapView(@NonNull Context context, @Nullable MapLibreMapOptions options) {
+  public MapView(@NonNull Context context, @NonNull MapLibreMapOptions options) {
     super(context);
     Timber.d("MapView constructed with context and MapLibreMapOptions");
-    initialize(context, options == null ? MapLibreMapOptions.createFromAttributes(context) : options);
+    initialize(context, options);
   }
 
   @CallSuper

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/renderer/MapRenderer.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/renderer/MapRenderer.java
@@ -82,6 +82,12 @@ public abstract class MapRenderer implements MapRendererScheduler {
       boolean useSwappy = options.getUseSwappy();
       boolean enableSwappyLogs = options.getEnableSwappyLogs();
       boolean enableSwappyFrameMetrics = options.getUseSwappyFrameMetrics();
+      if (useSwappy && !useModernEGL) {
+        Logger.w(TAG, "useSwappy=true requires useModernEGL=true; disabling Swappy to avoid "
+            + "initializing it on the legacy EGL path.");
+        useSwappy = false;
+      }
+
       renderer = MapRendererFactory.newSurfaceViewMapRenderer(context, localFontFamily,
               renderSurfaceOnTop, initCallback, threadPriorityOverride, useModernEGL);
 

--- a/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/maps/MapLibreMapOptionsTest.kt
+++ b/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/maps/MapLibreMapOptionsTest.kt
@@ -323,6 +323,53 @@ class MapLibreMapOptionsTest {
         )
     }
 
+    @Test
+    fun testSwappy_disabledByDefault() {
+        // Swappy and modern EGL must default to false so that callers opt in explicitly.
+        // Hardcoding them to true in createFromAttributes() caused Swappy to be silently
+        // active for any MapView inflated from XML, bypassing the caller's configuration.
+        val options = MapLibreMapOptions.createFromAttributes(RuntimeEnvironment.application, null)
+        Assert.assertFalse("useSwappy must default to false", options.useSwappy)
+        Assert.assertFalse("enableSwappyLogs must default to false", options.enableSwappyLogs)
+        Assert.assertFalse("useSwappyFrameMetrics must default to false", options.useSwappyFrameMetrics)
+        Assert.assertFalse("useModernEGL must default to false when Swappy is off", options.useModernEGL)
+    }
+
+    @Test
+    fun testSwappy_canBeEnabledExplicitly() {
+        val options = MapLibreMapOptions.createFromAttributes(RuntimeEnvironment.application, null)
+            .enableUseSwappy(true)
+            .enableSwappyLogs(true)
+            .enableSwappyFrameMetrics(true)
+        Assert.assertTrue(options.useSwappy)
+        Assert.assertTrue(options.enableSwappyLogs)
+        Assert.assertTrue(options.useSwappyFrameMetrics)
+    }
+
+    @Test
+    fun testSwappy_enableUseSwappy_impliesModernEGL() {
+        // Swappy requires the modern EGL path. Enabling Swappy must automatically
+        // enable modern EGL; disabling it must revert modern EGL to false.
+        val options = MapLibreMapOptions()
+        Assert.assertFalse(options.useModernEGL)
+
+        options.enableUseSwappy(true)
+        Assert.assertTrue("enableUseSwappy(true) must also set useModernEGL=true", options.useModernEGL)
+
+        options.enableUseSwappy(false)
+        Assert.assertFalse("enableUseSwappy(false) must also set useModernEGL=false", options.useModernEGL)
+    }
+
+    @Test
+    fun testSwappy_defaultConstructorDisabled() {
+        // The no-arg constructor must also default Swappy and modern EGL to false.
+        val options = MapLibreMapOptions()
+        Assert.assertFalse(options.useSwappy)
+        Assert.assertFalse(options.enableSwappyLogs)
+        Assert.assertFalse(options.useSwappyFrameMetrics)
+        Assert.assertFalse(options.useModernEGL)
+    }
+
     companion object {
         private const val DELTA = 1e-15
     }


### PR DESCRIPTION
There was a method that had hard-coded enablement of swappy which wasn't used prior but I believe something changed in the client code that leads to this method. This PR removed the hardcoded enablement.  This ticket https://rivianvwgroup.atlassian.net/browse/SYSINT-436475?focusedCommentId=1164716 lead to me to seeing that swapping buffers is done by swappy.