### PR TITLE
Add swappy integration during build

### DIFF
--- a/platform/android/SWAPPY_INTEGRATION.md
+++ b/platform/android/SWAPPY_INTEGRATION.md
@@ -37,6 +37,8 @@ CMake Configure
     ↓
 FetchContent auto-downloads Game SDK (if GAMESDK_DIR not set)
     ↓
+Patch ChoreographerShim.h for NDK 26+ compatibility
+    ↓
 Swappy CMake Build
     ↓
 libswappy_static.a
@@ -46,9 +48,183 @@ Link with MapLibre Native
 libmaplibre.so (single .so with static C++)
 ```
 
-## Technical Details
+## CMake Build System In Depth
 
-### 1. ANDROIDGAMESDK_NO_BINARY_DEX_LINKAGE
+The Swappy build is defined in `platform/android/third_party/swappy/CMakeLists.txt`. This
+file is the sole entry point for Swappy in the build graph, included only by
+`platform/android/MapLibreAndroid/src/cpp/CMakeLists.txt` when `MLN_WITH_OPENGL` is ON
+(the drawable and legacy flavors). It is never triggered by non-Android platforms.
+
+### Game SDK Source Resolution
+
+The CMake file resolves the Game SDK source directory using a three-level priority:
+
+```cmake
+# Priority 1: Environment variable (explicit override)
+if(DEFINED ENV{GAMESDK_DIR})
+    set(GAMESDK_DIR "$ENV{GAMESDK_DIR}")
+
+# Priority 2: CMake variable (e.g. -DGAMESDK_DIR=... or FETCHCONTENT_SOURCE_DIR_GAMESDK)
+elseif(NOT DEFINED GAMESDK_DIR)
+
+    # Priority 3: Auto-download from googlesource via FetchContent
+    include(FetchContent)
+    FetchContent_Declare(
+        gamesdk
+        GIT_REPOSITORY https://android.googlesource.com/platform/frameworks/opt/gamesdk
+        GIT_TAG 044fd03c4a7d3b75aeb6ca2bd7fb6155d2cdb787
+        GIT_SHALLOW TRUE
+        GIT_PROGRESS TRUE
+    )
+    FetchContent_GetProperties(gamesdk)
+    if(NOT gamesdk_POPULATED)
+        FetchContent_Populate(gamesdk)
+        # ... patch ChoreographerShim.h (see below) ...
+    endif()
+    set(GAMESDK_DIR "${gamesdk_SOURCE_DIR}")
+endif()
+```
+
+**Why `FetchContent_Populate` instead of `FetchContent_MakeAvailable`:**
+The Game SDK repo contains `build.gradle` and `settings.gradle` at its root. If the repo
+ever adds a `CMakeLists.txt`, `FetchContent_MakeAvailable` would automatically call
+`add_subdirectory()` on the entire Game SDK project, pulling in unrelated build targets.
+Using `FetchContent_Populate` explicitly downloads the source without attempting to
+configure or build anything from it. We then manually reference only the specific source
+files we need.
+
+**Why the canonical googlesource repo:**
+The Game SDK source lives at `https://android.googlesource.com/platform/frameworks/opt/gamesdk`.
+This is the authoritative upstream (maintained by Google's AGDK team), as opposed to the
+`github.com/android/games-samples` mirror which reorganizes the source under `agdk/agde/`.
+The googlesource repo has the standard layout that our CMakeLists.txt expects:
+`games-frame-pacing/`, `include/swappy/`, and `src/common/`.
+
+**Why `GIT_SHALLOW TRUE`:**
+The full Game SDK repo history is large. Shallow clone fetches only the single commit we
+reference, reducing the download from hundreds of MB to ~10-20 MB.
+
+**Pinning to a specific commit:**
+The `GIT_TAG` is set to a specific commit hash (`044fd03c...`) rather than a branch name
+like `main`. This ensures reproducible builds -- every developer and CI system builds
+against exactly the same Game SDK source. To update, replace the hash and clean rebuild.
+
+### ChoreographerShim.h Patch (NDK 26+ Compatibility)
+
+After FetchContent downloads the Game SDK source, the build automatically patches
+`src/common/ChoreographerShim.h` to fix a compilation error with NDK 26+.
+
+**The Problem:**
+
+The Game SDK's `ChoreographerShim.h` was written for older NDKs where Choreographer APIs
+above the target API level were not declared in the NDK headers. It provides fallback
+typedefs guarded by `#if __ANDROID_API__ < 33`:
+
+```c
+// In the upstream (unpatched) ChoreographerShim.h:
+#if __ANDROID_API__ < 33
+
+// These are typedef'd as function POINTER types, intended for use with dlsym():
+typedef void (*AChoreographer_postVsyncCallback)(...);
+typedef size_t (*AChoreographerFrameCallbackData_getPreferredFrameTimelineIndex)(...);
+typedef int64_t (*AChoreographerFrameCallbackData_getFrameTimelineExpectedPresentationTimeNanos)(...);
+typedef int64_t (*AChoreographerFrameCallbackData_getFrameTimelineDeadlineNanos)(...);
+
+#endif
+```
+
+Starting with NDK r26, the NDK headers declare ALL Choreographer APIs unconditionally
+using `__attribute__((availability(...)))` annotations (defined via the `__INTRODUCED_IN`
+macro in `<android/versioning.h>`). This means `AChoreographer_postVsyncCallback` etc. are
+now declared as **actual function declarations** in `<android/choreographer.h>`, regardless
+of the target API level:
+
+```c
+// In NDK 26's choreographer.h -- always present regardless of __ANDROID_API__:
+void AChoreographer_postVsyncCallback(AChoreographer* choreographer,
+                                        AChoreographer_vsyncCallback callback, void* data)
+        __INTRODUCED_IN(33);
+```
+
+When `__ANDROID_API__ < 33` (e.g., targeting API 21), both declarations are visible:
+the NDK's **function declaration** and the Game SDK's **typedef with the same name**. The
+compiler sees this as "redefinition of 'AChoreographer_postVsyncCallback' as different kind
+of symbol" and emits a fatal error.
+
+**The Fix:**
+
+The build patches the guard to also check `__NDK_MAJOR__` (defined in
+`<android/ndk-version.h>`, available in all NDK versions):
+
+```cmake
+# In CMakeLists.txt, after FetchContent_Populate:
+string(REPLACE
+    "#if __ANDROID_API__ < 33"
+    "#if __ANDROID_API__ < 33 && (!defined(__NDK_MAJOR__) || __NDK_MAJOR__ < 26)"
+    _shim_contents "${_shim_contents}")
+```
+
+This changes the guard in `ChoreographerShim.h` to:
+
+```c
+#if __ANDROID_API__ < 33 && (!defined(__NDK_MAJOR__) || __NDK_MAJOR__ < 26)
+```
+
+**Effect:** On NDK 26+, the entire `#if` block is skipped. The function declarations from
+the NDK header are used directly, and the conflicting typedefs are never defined. On older
+NDKs (< 26), the behavior is unchanged -- the shim typedefs are still provided as before.
+
+**Why this is done at CMake configure time (not a .patch file):**
+Using `file(READ)` + `string(REPLACE)` + `file(WRITE)` in CMake is self-contained -- no
+external `patch` or `git apply` dependency required. The patch runs once (guarded by
+`if(NOT gamesdk_POPULATED)`) and modifies the fetched source in-place. Subsequent
+configures reuse the already-patched source.
+
+### Validation After Build
+
+The build automatically validates that `GAMESDK_DIR` points to a valid Game SDK checkout:
+
+```cmake
+if(NOT EXISTS "${GAMESDK_DIR}/games-frame-pacing")
+    message(FATAL_ERROR
+        "Game SDK not found at ${GAMESDK_DIR}\n"
+        "Either:\n"
+        "  - Let the build auto-download it (remove GAMESDK_DIR override), or\n"
+        "  - Set GAMESDK_DIR env var to a valid Game SDK checkout containing games-frame-pacing/")
+endif()
+```
+
+This catches misconfigured `GAMESDK_DIR` overrides early with a clear error message.
+
+### Source Files Compiled
+
+The `swappy_static` library is built from these Game SDK source files:
+
+| Category | Files | Purpose |
+|----------|-------|---------|
+| **Common** | `ChoreographerFilter.cpp`, `ChoreographerThread.cpp`, `CpuInfo.cpp`, `Settings.cpp`, `Thread.cpp`, `SwappyCommon.cpp`, `swappy_c.cpp`, `SwappyDisplayManager.cpp`, `CPUTracer.cpp`, `FrameStatistics.cpp` | Core frame pacing logic, choreographer integration, frame statistics |
+| **OpenGL** | `EGL.cpp`, `swappyGL_c.cpp`, `SwappyGL.cpp`, `FrameStatisticsGL.cpp` | OpenGL ES swap chain management, EGL buffer control |
+| **Vulkan** | `swappyVk_c.cpp`, `SwappyVk.cpp`, `SwappyVkBase.cpp`, `SwappyVkFallback.cpp`, `SwappyVkGoogleDisplayTiming.cpp` | Vulkan present timing (compiled but only Vulkan entry points are unused in our OpenGL build) |
+| **Utils** | `system_utils.cpp` | Platform detection and system property access |
+
+### Linking
+
+The `swappy_static` library links against:
+- `android` -- Native Android APIs (Choreographer, Looper)
+- `log` -- Android logging
+- `GLESv2` -- OpenGL ES 2.0
+- `EGL` -- EGL display/surface management
+
+It is then linked into the main `maplibre` shared library:
+```cmake
+# In MapLibreAndroid/src/cpp/CMakeLists.txt:
+add_subdirectory(../../../third_party/swappy ${CMAKE_CURRENT_BINARY_DIR}/swappy)
+target_link_libraries(maplibre PRIVATE swappy_static)
+```
+
+## Other Technical Details
+
+### ANDROIDGAMESDK_NO_BINARY_DEX_LINKAGE
 
 **What it does:**
 - Disables the Game SDK's embedded DEX approach
@@ -59,7 +235,7 @@ The Game SDK supports two methods for providing Java support classes:
 
 | Approach | Description | Pros | Cons |
 |----------|-------------|------|------|
-| **Embedded DEX** (default) | Compile Java → DEX → embed binary in `.so` → extract at runtime | Self-contained | Complex, requires linker symbols |
+| **Embedded DEX** (default) | Compile Java -> DEX -> embed binary in `.so` -> extract at runtime | Self-contained | Complex, requires linker symbols |
 | **Classpath** (our choice) | Include Java classes in AAR normally | Simple, standard Android | Requires Java sources in library |
 
 **Implementation:**
@@ -72,44 +248,29 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DANDROIDGAMESDK_NO_BINARY_DEX_LINKAGE")
 // Added to MapLibre source tree
 com/google/androidgamesdk/
 ├── SwappyDisplayManager.java      # Display refresh rate management
-├── ChoreographerCallback.java     # Frame callback handling  
+├── ChoreographerCallback.java     # Frame callback handling
 └── GameSdkDeviceInfoJni.java      # Device info (optional)
 ```
 
-**Why this is better:**
-- ✅ Standard Android library pattern
-- ✅ No special build tools required
-- ✅ No runtime DEX extraction overhead
-- ✅ Easier to debug and maintain
-
-### 2. Static Library Configuration
+### Static Library Configuration
 
 **build.gradle.kts:**
 ```kotlin
 arguments("-DANDROID_STL=c++_static")  // All build flavors
-// Removed: implementation(libs.gamesFramePacing)  
+// Removed: implementation(libs.gamesFramePacing)
 // Removed: prefab = true
 ```
 
-**CMakeLists.txt:**
-```cmake
-add_subdirectory(../../../third_party/swappy ${CMAKE_CURRENT_BINARY_DIR}/swappy)
-target_link_libraries(maplibre PRIVATE swappy_static)
-```
-
-### 3. NDK Compatibility
+### NDK Compatibility
 
 **NDK Version:** 26.1.10909125
 
 **Why this version:**
-- ✅ Provides C++20 support for MapLibre Native (`<numbers>`, `std::ranges`)
-- ✅ Compatible with Game SDK source code
-- ✅ Native Choreographer API support (reduces shim complexity)
+- Provides C++20 support for MapLibre Native (`<numbers>`, `std::ranges`)
+- Compatible with Game SDK source code
+- Native Choreographer API support (reduces shim complexity)
 
-**Patches Applied:**
-- Modified `ChoreographerShim.h` to skip typedef conflicts with NDK 26's native definitions
-
-### 4. Compiler Flags
+### Compiler Flags
 
 ```cmake
 -std=c++17                              # Swappy requires C++17
@@ -126,22 +287,16 @@ target_link_libraries(maplibre PRIVATE swappy_static)
 |------|--------|--------|
 | `MapLibreAndroid/build.gradle.kts` | Set `-DANDROID_STL=c++_static` | Use static C++ library |
 | `MapLibreAndroid/src/cpp/CMakeLists.txt` | Add Swappy subdirectory | Build Swappy from source |
-| `buildSrc/src/main/kotlin/Versions.kt` | NDK → 26.1.10909125 | C++20 support + compatibility |
-| `third_party/gamesdk/src/common/ChoreographerShim.h` | Add NDK version check | Avoid typedef conflicts |
-| `.gitignore` | Add `third_party/gamesdk/` | Prevent accidental commits |
+| `buildSrc/src/main/kotlin/Versions.kt` | NDK -> 26.1.10909125 | C++20 support + compatibility |
 
 ### Added Files
 
 | File | Purpose |
 |------|---------|
-| `third_party/swappy/CMakeLists.txt` | Build configuration for Swappy |
-| `third_party/swappy/README.md` | Documentation |
+| `third_party/swappy/CMakeLists.txt` | Build config: auto-fetch, patch, compile Swappy from source |
+| `third_party/swappy/README.md` | Quick-start documentation |
 | `MapLibreAndroid/src/main/java/com/google/androidgamesdk/*.java` | Java support classes (3 files) |
 | `SWAPPY_INTEGRATION.md` | This document |
-
-### Removed
-
-- `third_party/gamesdk/` → Moved to `~/android-gamesdk/` (252 MB removed from repo)
 
 ## Verification
 
@@ -212,8 +367,20 @@ Update the `GIT_TAG` commit hash in `third_party/swappy/CMakeLists.txt`, then cl
 | `Game SDK not found at ...` | `GAMESDK_DIR` points to invalid path | Fix the path or unset `GAMESDK_DIR` to use auto-download |
 | `_binary_classes_dex_start undefined` | Missing DEX linkage flag | Verify `ANDROIDGAMESDK_NO_BINARY_DEX_LINKAGE` in CMakeLists.txt |
 | `<numbers> file not found` | NDK too old | Use NDK 26.1.10909125+ |
-| `AChoreographer_postVsyncCallback redefinition` | NDK version conflict | Applied patch to ChoreographerShim.h |
+| `AChoreographer_postVsyncCallback redefinition` | NDK 26+ vs Game SDK typedef conflict | See "ChoreographerShim.h Patch" section above; if using `GAMESDK_DIR` override, you must patch your local copy manually |
 | FetchContent download failure | Network issue or git not available | Check connectivity; or set `GAMESDK_DIR` for offline builds |
+| FetchContent clone hangs | Corporate firewall blocking googlesource.com | Clone manually and use `GAMESDK_DIR` or `FETCHCONTENT_SOURCE_DIR_GAMESDK` |
+
+**Note on `GAMESDK_DIR` override and the ChoreographerShim patch:**
+The automatic ChoreographerShim.h patch only runs when FetchContent downloads the source
+(Priority 3). If you provide your own Game SDK checkout via `GAMESDK_DIR`, you are
+responsible for ensuring it is compatible with your NDK version. For NDK 26+, you must
+manually apply the same fix to `src/common/ChoreographerShim.h` in your checkout:
+
+```diff
+- #if __ANDROID_API__ < 33
++ #if __ANDROID_API__ < 33 && (!defined(__NDK_MAJOR__) || __NDK_MAJOR__ < 26)
+```
 
 ### Runtime Errors
 

--- a/platform/android/SWAPPY_INTEGRATION.md
+++ b/platform/android/SWAPPY_INTEGRATION.md
@@ -17,22 +17,25 @@ MapLibre Native and `android-spatialite` both included `libc++_shared.so`, causi
 
 1. **Static C++ Linking**: Build MapLibre Native with `libc++_static` instead of `libc++_shared`
 2. **Swappy from Source**: Build Swappy statically from Game SDK source (not available as prebuilt static library)
-3. **External Source Management**: Keep Game SDK source outside the repository to avoid bloat
+3. **Auto-Download via FetchContent**: Game SDK source is automatically fetched during the first build -- no manual setup required
 
 ## Architecture Changes
 
 ### Repository Size Impact
 - **Before:** `third_party/` = 252 MB (with embedded Game SDK source)
 - **After:** `third_party/` = 12 KB (build config only)
-- **Reduction:** 99.995% smaller ✅
+- **Reduction:** 99.995% smaller
 
 ### Build Configuration
 
-**Location:** `/home/sid/android-gamesdk/gamesdk/` (external to repo)
+**Source:** Auto-fetched into `<build-dir>/_deps/gamesdk-src/` via CMake FetchContent
+(or manual override via `GAMESDK_DIR` env var)
 
 **Build Flow:**
 ```
-Game SDK Source (external)
+CMake Configure
+    ↓
+FetchContent auto-downloads Game SDK (if GAMESDK_DIR not set)
     ↓
 Swappy CMake Build
     ↓
@@ -173,39 +176,32 @@ Swappy: Initialized successfully
 
 ## Developer Workflow
 
-### One-time Setup
-```bash
-# 1. Clone Game SDK
-cd ~
-git clone https://github.com/android/games-samples.git
-mkdir -p android-gamesdk
-ln -s ~/games-samples/agdk/agde android-gamesdk/gamesdk
-
-# 2. Verify structure
-ls ~/android-gamesdk/gamesdk/games-frame-pacing/
-```
-
-### Build Process
+### Build (no setup required)
 ```bash
 cd ~/mln-proton/platform/android
-
-# Clean build
-./gradlew clean :MapLibreAndroid:assembleDrawableRelease
+./gradlew :MapLibreAndroid:assembleDrawableRelease
 
 # The build automatically:
-# 1. Finds Game SDK at ~/android-gamesdk/gamesdk
+# 1. Fetches Game SDK via FetchContent (first build only)
 # 2. Compiles Swappy from source
 # 3. Links statically with MapLibre
 # 4. Packages Java classes into AAR
 ```
 
-### Updating Game SDK
+### Using a local Game SDK (optional)
 ```bash
-cd ~/android-gamesdk/gamesdk
-git pull
-cd ~/mln-proton/platform/android
-./gradlew clean :MapLibreAndroid:assembleDrawableRelease
+export GAMESDK_DIR=/path/to/your/gamesdk
+./gradlew :MapLibreAndroid:assembleDrawableRelease
 ```
+
+### CI caching
+```bash
+# Pre-populate the FetchContent cache to avoid re-downloading
+cmake ... -DFETCHCONTENT_SOURCE_DIR_GAMESDK=/path/to/cached/gamesdk
+```
+
+### Updating the pinned Game SDK version
+Update the `GIT_TAG` commit hash in `third_party/swappy/CMakeLists.txt`, then clean and rebuild.
 
 ## Troubleshooting
 
@@ -213,10 +209,11 @@ cd ~/mln-proton/platform/android
 
 | Error | Cause | Solution |
 |-------|-------|----------|
-| `Cannot find GAMESDK_DIR` | Game SDK not at expected location | Ensure `~/android-gamesdk/gamesdk` exists or set `GAMESDK_DIR` env var |
+| `Game SDK not found at ...` | `GAMESDK_DIR` points to invalid path | Fix the path or unset `GAMESDK_DIR` to use auto-download |
 | `_binary_classes_dex_start undefined` | Missing DEX linkage flag | Verify `ANDROIDGAMESDK_NO_BINARY_DEX_LINKAGE` in CMakeLists.txt |
 | `<numbers> file not found` | NDK too old | Use NDK 26.1.10909125+ |
 | `AChoreographer_postVsyncCallback redefinition` | NDK version conflict | Applied patch to ChoreographerShim.h |
+| FetchContent download failure | Network issue or git not available | Check connectivity; or set `GAMESDK_DIR` for offline builds |
 
 ### Runtime Errors
 
@@ -241,12 +238,7 @@ cd ~/mln-proton/platform/android
 
 - [Android Game SDK](https://developer.android.com/games/sdk)
 - [Swappy Frame Pacing](https://developer.android.com/games/sdk/frame-pacing)
-- [Game SDK Source](https://github.com/android/games-samples/tree/main/agdk)
+- [Game SDK Source (googlesource)](https://android.googlesource.com/platform/frameworks/opt/gamesdk)
 - [NDK C++ Library Support](https://developer.android.com/ndk/guides/cpp-support)
 - [Static vs Shared STL](https://developer.android.com/ndk/guides/cpp-support#static_runtimes)
-
-## Credits
-
-Integration completed: October 30, 2024
-Configuration: Static C++ library with external source management
 

--- a/platform/android/third_party/swappy/CMakeLists.txt
+++ b/platform/android/third_party/swappy/CMakeLists.txt
@@ -2,13 +2,39 @@ cmake_minimum_required(VERSION 3.18.1)
 project(swappy C CXX)
 set(CMAKE_CXX_STANDARD 17)
 
-# Swappy source directories (external to MapLibre Native repo)
-# Set GAMESDK_DIR environment variable or it defaults to ~/android-gamesdk
+# Resolve the Android Game SDK source directory.
+#
+# Priority order:
+#   1. GAMESDK_DIR environment variable (explicit override)
+#   2. GAMESDK_DIR CMake variable (e.g. -DGAMESDK_DIR=... or FETCHCONTENT_SOURCE_DIR_GAMESDK)
+#   3. Auto-download via FetchContent from googlesource (default for fresh builds)
 if(DEFINED ENV{GAMESDK_DIR})
     set(GAMESDK_DIR "$ENV{GAMESDK_DIR}")
-else()
-    set(GAMESDK_DIR "$ENV{HOME}/android-gamesdk/gamesdk")
+elseif(NOT DEFINED GAMESDK_DIR)
+    include(FetchContent)
+    FetchContent_Declare(
+        gamesdk
+        GIT_REPOSITORY https://android.googlesource.com/platform/frameworks/opt/gamesdk
+        GIT_TAG 044fd03c4a7d3b75aeb6ca2bd7fb6155d2cdb787
+        GIT_SHALLOW TRUE
+        GIT_PROGRESS TRUE
+    )
+    FetchContent_GetProperties(gamesdk)
+    if(NOT gamesdk_POPULATED)
+        FetchContent_Populate(gamesdk)
+    endif()
+    set(GAMESDK_DIR "${gamesdk_SOURCE_DIR}")
+    message(STATUS "Swappy: auto-fetched Game SDK to ${GAMESDK_DIR}")
 endif()
+
+if(NOT EXISTS "${GAMESDK_DIR}/games-frame-pacing")
+    message(FATAL_ERROR
+        "Game SDK not found at ${GAMESDK_DIR}\n"
+        "Either:\n"
+        "  - Let the build auto-download it (remove GAMESDK_DIR override), or\n"
+        "  - Set GAMESDK_DIR env var to a valid Game SDK checkout containing games-frame-pacing/")
+endif()
+
 set(SWAPPY_DIR "${GAMESDK_DIR}/games-frame-pacing")
 
 # Compiler flags from original Swappy build (relaxed for compatibility)

--- a/platform/android/third_party/swappy/CMakeLists.txt
+++ b/platform/android/third_party/swappy/CMakeLists.txt
@@ -22,6 +22,20 @@ elseif(NOT DEFINED GAMESDK_DIR)
     FetchContent_GetProperties(gamesdk)
     if(NOT gamesdk_POPULATED)
         FetchContent_Populate(gamesdk)
+
+        # NDK 26+ declares all Choreographer APIs unconditionally (with availability attributes),
+        # which conflicts with the Game SDK's ChoreographerShim.h typedefs that share the same
+        # names. Patch the guard to also check __NDK_MAJOR__.
+        set(_shim_file "${gamesdk_SOURCE_DIR}/src/common/ChoreographerShim.h")
+        if(EXISTS "${_shim_file}")
+            file(READ "${_shim_file}" _shim_contents)
+            string(REPLACE
+                "#if __ANDROID_API__ < 33"
+                "#if __ANDROID_API__ < 33 && (!defined(__NDK_MAJOR__) || __NDK_MAJOR__ < 26)"
+                _shim_contents "${_shim_contents}")
+            file(WRITE "${_shim_file}" "${_shim_contents}")
+            message(STATUS "Swappy: patched ChoreographerShim.h for NDK 26+ compatibility")
+        endif()
     endif()
     set(GAMESDK_DIR "${gamesdk_SOURCE_DIR}")
     message(STATUS "Swappy: auto-fetched Game SDK to ${GAMESDK_DIR}")

--- a/platform/android/third_party/swappy/README.md
+++ b/platform/android/third_party/swappy/README.md
@@ -4,60 +4,58 @@ This directory contains the build configuration for integrating [Android Game SD
 
 ## Overview
 
-Swappy is built from source as a **static library** using `libc++_static` to avoid conflicts with other native dependencies. The Game SDK source code is kept **outside the MapLibre Native repository** to reduce repository size.
+Swappy is built from source as a **static library** using `libc++_static` to avoid conflicts with other native dependencies. The Game SDK source is **automatically downloaded** during the first build via CMake's FetchContent. No manual setup is required.
 
-## Directory Structure
+## Quick Start
 
-```
-~/android-gamesdk/gamesdk/           # Game SDK source (external, not in repo)
-  └── games-frame-pacing/            # Swappy source code
-      ├── common/
-      ├── opengl/
-      └── vulkan/
-
-~/mln-proton/platform/android/
-  ├── third_party/swappy/
-  │   ├── CMakeLists.txt             # Build configuration (in repo)
-  │   └── README.md                  # This file
-  └── MapLibreAndroid/src/main/java/com/google/androidgamesdk/
-      ├── SwappyDisplayManager.java  # Java support classes
-      ├── ChoreographerCallback.java
-      └── GameSdkDeviceInfoJni.java
-```
-
-## Initial Setup
-
-### 1. Download Game SDK Source
-
-```bash
-cd ~
-git clone https://github.com/android/games-samples.git
-cd games-samples/agdk
-# The gamesdk directory should be at ~/games-samples/agdk/agde/
-```
-
-**Note:** If you cloned it to a different location, create a symbolic link:
-```bash
-mkdir -p ~/android-gamesdk
-ln -s ~/games-samples/agdk/agde ~/android-gamesdk/gamesdk
-```
-
-Or set the `GAMESDK_DIR` environment variable:
-```bash
-export GAMESDK_DIR=/path/to/your/gamesdk
-```
-
-### 2. Verify Directory Structure
-
-Ensure the following files exist:
-- `~/android-gamesdk/gamesdk/include/swappy/swappyGL.h`
-- `~/android-gamesdk/gamesdk/games-frame-pacing/common/SwappyCommon.cpp`
-
-### 3. Build MapLibre Native
+Just build -- no extra setup needed:
 
 ```bash
 cd ~/mln-proton/platform/android
 ./gradlew :MapLibreAndroid:assembleDrawableRelease
+```
+
+On the first build, CMake will automatically fetch the Android Game SDK source from
+`https://android.googlesource.com/platform/frameworks/opt/gamesdk` into the build
+directory. Subsequent builds reuse the cached download.
+
+## Advanced: Using a Local Game SDK Checkout
+
+If you prefer to use a local checkout (e.g., for offline builds or custom patches),
+set the `GAMESDK_DIR` environment variable:
+
+```bash
+export GAMESDK_DIR=/path/to/your/gamesdk
+```
+
+This skips the auto-download and uses your local copy instead. The directory must
+contain `games-frame-pacing/`, `include/swappy/`, and `src/common/`.
+
+For CI caching, you can also use CMake's built-in override:
+
+```bash
+-DFETCHCONTENT_SOURCE_DIR_GAMESDK=/path/to/cached/gamesdk
+```
+
+## Directory Structure
+
+```
+<build-dir>/_deps/gamesdk-src/      # Auto-fetched Game SDK (in build dir, not in repo)
+  ├── include/swappy/               # Public headers
+  ├── games-frame-pacing/           # Swappy source code
+  │   ├── common/
+  │   ├── opengl/
+  │   └── vulkan/
+  └── src/common/                   # Shared utilities
+
+platform/android/
+  ├── third_party/swappy/
+  │   ├── CMakeLists.txt            # Build configuration (in repo)
+  │   └── README.md                 # This file
+  └── MapLibreAndroid/src/main/java/com/google/androidgamesdk/
+      ├── SwappyDisplayManager.java # Java support classes
+      ├── ChoreographerCallback.java
+      └── GameSdkDeviceInfoJni.java
 ```
 
 ## How It Works
@@ -65,7 +63,8 @@ cd ~/mln-proton/platform/android
 ### Build Process
 
 1. **CMake Configuration** (`CMakeLists.txt`):
-   - Locates Game SDK source at `~/android-gamesdk/gamesdk` (or `$GAMESDK_DIR`)
+   - Checks for `GAMESDK_DIR` env var (manual override)
+   - If not set, auto-fetches the Game SDK via FetchContent (pinned to a known-good commit)
    - Compiles Swappy C++ sources into `libswappy_static.a`
    - Uses `-DANDROIDGAMESDK_NO_BINARY_DEX_LINKAGE` to skip embedded DEX
 
@@ -126,21 +125,24 @@ const val ndkVersion = "26.1.10909125"
 
 ## Maintenance
 
-### Updating Game SDK
+### Updating the Pinned Game SDK Version
 
-```bash
-cd ~/android-gamesdk/gamesdk
-git pull
-# Then rebuild MapLibre Native
-cd ~/mln-proton/platform/android
-./gradlew clean :MapLibreAndroid:assembleDrawableRelease
-```
+The Game SDK is pinned to a specific commit in `CMakeLists.txt` (the `GIT_TAG` in the
+`FetchContent_Declare` call). To update:
+
+1. Find the desired commit hash from
+   https://android.googlesource.com/platform/frameworks/opt/gamesdk/+log/refs/heads/main
+2. Update the `GIT_TAG` value in `CMakeLists.txt`
+3. Clean and rebuild:
+   ```bash
+   ./gradlew clean :MapLibreAndroid:assembleDrawableRelease
+   ```
 
 ### Troubleshooting
 
-**Build Error: "Cannot find GAMESDK_DIR"**
-- Ensure `~/android-gamesdk/gamesdk` exists
-- Or set `GAMESDK_DIR` environment variable
+**Build Error: "Game SDK not found at ..."**
+- If using `GAMESDK_DIR`, verify the path contains `games-frame-pacing/`
+- If auto-downloading, check your network connection and try a clean build
 
 **Runtime Error: "jmethodID was NULL"**
 - Java classes are missing from the AAR
@@ -150,6 +152,11 @@ cd ~/mln-proton/platform/android
 **Linker Error: "_binary_classes_dex_start undefined"**
 - `ANDROIDGAMESDK_NO_BINARY_DEX_LINKAGE` flag is missing
 - Check `CMakeLists.txt` for the flag in `CMAKE_CXX_FLAGS`
+
+**Slow first build**
+- The initial FetchContent clone is a one-time cost (~10-20 MB shallow clone)
+- Subsequent builds reuse the cached source in `<build-dir>/_deps/gamesdk-src/`
+- For CI, pre-populate the cache with `-DFETCHCONTENT_SOURCE_DIR_GAMESDK=...`
 
 ## References
 


### PR DESCRIPTION
This PR fetch games-sdk via cmake fetch and applies the patch for choreographershim.

The swappy integration is documented in detail for future or if anyone wants to read.
