### PR TITLE
Support for high resolution traffic

### DIFF
--- a/include/mbgl/route/route.hpp
+++ b/include/mbgl/route/route.hpp
@@ -65,13 +65,14 @@ public:
 
     std::string segmentsToString(uint32_t tabcount) const;
 
-private:
     struct SegmentRange {
         std::pair<double, double> range;
         Color color;
     };
 
     std::vector<SegmentRange> compactSegments(const RouteType& routeType) const;
+
+private:
     Point<double> getPointCoarse(double percent, double* bearing = nullptr) const;
     Point<double> getPointFine(double percent, double* bearing = nullptr) const;
     double getProgressProjectionLERP(const Point<double>& queryPoint, bool capture = false);

--- a/include/mbgl/route/route_manager.hpp
+++ b/include/mbgl/route/route_manager.hpp
@@ -102,6 +102,9 @@ public:
     bool hasRoutes() const;
     void finalize();
 
+    void setUseHighPrecisionTraffic(bool useHighPrecision);
+    bool getUseHighPrecisionTraffic() const;
+
     ~RouteManager();
 
 private:
@@ -138,6 +141,8 @@ private:
     std::unordered_map<RouteID, double, IDHasher<RouteID>> previousProgressMap_;
     // Threshold for what constitutes a large delta (default 20% = 0.20)
     double largeDeltaThreshold_ = 0.20;
+
+    bool useHighPrecisionTraffic_ = false;
 };
 }; // namespace route
 

--- a/include/mbgl/shaders/gl/drawable_line_gradient.hpp
+++ b/include/mbgl/shaders/gl/drawable_line_gradient.hpp
@@ -176,6 +176,13 @@ mediump float width = u_width;
     lowp float props_pad2;
 };
 
+layout (std140) uniform LineTrafficSegmentsUBO {
+    vec4 u_traffic_data[64];
+    int u_use_high_precision;
+    int u_traffic_segment_count;
+    float traffic_pad1, traffic_pad2;
+};
+
 uniform sampler2D u_image;
 
 in vec2 v_width2;
@@ -209,11 +216,25 @@ lowp float opacity = u_opacity;
     float blur2 = (blur + 1.0 / DEVICE_PIXEL_RATIO) * v_gamma_scale;
     float alpha = clamp(min(dist - (v_width2.t - blur2), v_width2.s - dist) / blur2, 0.0, 1.0);
 
-    // For gradient lines, v_lineprogress is the ratio along the entire line,
-    // scaled to [0, 2^15), and the gradient ramp is stored in a texture.
-    vec4 color = texture(u_image, vec2(v_lineprogress, 0.5));
+    vec4 color;
+    if (u_use_high_precision != 0) {
+        color = u_color;
+        for (int i = 0; i < u_traffic_segment_count; i++) {
+            int idx = i * 2;
+            vec4 segColor = u_traffic_data[idx];
+            vec4 segRange = u_traffic_data[idx + 1];
+            if (v_lineprogress >= segRange.x && v_lineprogress < segRange.y) {
+                color = segColor;
+                break;
+            }
+        }
+    } else {
+        // For gradient lines, v_lineprogress is the ratio along the entire line,
+        // scaled to [0, 2^15), and the gradient ramp is stored in a texture.
+        color = texture(u_image, vec2(v_lineprogress, 0.5));
+    }
 
-    if(v_lineprogress <= v_line_clip) {
+    if (v_lineprogress <= v_line_clip) {
         color = v_clip_color;
     }
 

--- a/include/mbgl/shaders/line_layer_ubo.hpp
+++ b/include/mbgl/shaders/line_layer_ubo.hpp
@@ -50,6 +50,30 @@ struct alignas(16) LineGradientDrawableUBO {
 static_assert(sizeof(LineGradientDrawableUBO) == 7 * 16);
 
 //
+// Route traffic segments (high-precision UBO path)
+
+constexpr int MAX_ROUTE_TRAFFIC_SEGMENTS = 32;
+
+struct alignas(16) RouteTrafficSegmentData {
+    /*  0 */ std::array<float, 4> color;
+    /* 16 */ float start;
+    /* 20 */ float end;
+    /* 24 */ float pad1;
+    /* 28 */ float pad2;
+    /* 32 */
+};
+static_assert(sizeof(RouteTrafficSegmentData) == 2 * 16);
+
+struct alignas(16) LineTrafficSegmentsUBO {
+    /*    0 */ RouteTrafficSegmentData segments[MAX_ROUTE_TRAFFIC_SEGMENTS];
+    /* 1024 */ int useHighPrecision;
+    /* 1028 */ int segmentCount;
+    /* 1032 */ float pad1, pad2;
+    /* 1040 */
+};
+static_assert(sizeof(LineTrafficSegmentsUBO) == 65 * 16);
+
+//
 // Line pattern
 
 struct alignas(16) LinePatternDrawableUBO {

--- a/include/mbgl/shaders/shader_defines.hpp
+++ b/include/mbgl/shaders/shader_defines.hpp
@@ -198,6 +198,7 @@ enum {
 enum {
     idLineEvaluatedPropsUBO = getLayerStartValue(lineDrawableUBOCount),
     idLineExpressionUBO,
+    idLineTrafficSegmentsUBO,
     lineUBOCount
 };
 

--- a/include/mbgl/style/layers/line_layer.hpp
+++ b/include/mbgl/style/layers/line_layer.hpp
@@ -123,6 +123,17 @@ public:
 
     void setIsLayerUsingRoute(bool isRouteLayer);
     bool getIsLayerUsingRoute() const;
+
+    void setUseHighPrecisionTraffic(bool useHighPrecision);
+    bool getUseHighPrecisionTraffic() const;
+
+    struct TrafficSegment {
+        double start;
+        double end;
+        Color color;
+    };
+    void setTrafficSegments(std::vector<TrafficSegment> segments);
+
     // Private implementation
 
     class Impl;

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -107,6 +107,7 @@ NativeMapView::NativeMapView(jni::JNIEnv& _env,
     // Create a renderer frontend
     rendererFrontend = AndroidRendererFrontend::create(_env, jMapRenderer);
     routeMgr = std::make_unique<mbgl::route::RouteManager>();
+    routeMgr->setUseHighPrecisionTraffic(true);
 
     // Create Map options
     MapOptions options;
@@ -1716,17 +1717,15 @@ jint NativeMapView::routeCreate(JNIEnv& env,
             // Validate the converted linestring
             if (linestring.empty()) {
                 jni::ThrowNew(env,
-                             jni::FindClass(env, "java/lang/IllegalArgumentException"),
-                             "Route geometry cannot be empty - must contain at least 2 points");
+                              jni::FindClass(env, "java/lang/IllegalArgumentException"),
+                              "Route geometry cannot be empty - must contain at least 2 points");
                 return -1;
             }
 
             if (linestring.size() < 2) {
                 std::string msg = "Route geometry must contain at least 2 points, got: " +
-                                 std::to_string(linestring.size());
-                jni::ThrowNew(env,
-                             jni::FindClass(env, "java/lang/IllegalArgumentException"),
-                             msg.c_str());
+                                  std::to_string(linestring.size());
+                jni::ThrowNew(env, jni::FindClass(env, "java/lang/IllegalArgumentException"), msg.c_str());
                 return -1;
             }
 
@@ -1986,10 +1985,10 @@ void NativeMapView::onPreCompileShader(shaders::BuiltIn id,
     static auto onPreCompileShader = javaClass.GetMethod<void(jni::jint, jni::jint, jni::String)>(*_env,
                                                                                                   "onPreCompileShader");
     cachedJavaPeer.Call(*_env,
-                       onPreCompileShader,
-                       static_cast<jni::jint>(id),
-                       static_cast<jni::jint>(type),
-                       jni::Make<jni::String>(*_env, additionalDefines));
+                        onPreCompileShader,
+                        static_cast<jni::jint>(id),
+                        static_cast<jni::jint>(type),
+                        jni::Make<jni::String>(*_env, additionalDefines));
 }
 
 void NativeMapView::onPostCompileShader(shaders::BuiltIn id,
@@ -2006,10 +2005,10 @@ void NativeMapView::onPostCompileShader(shaders::BuiltIn id,
     static auto onPostCompileShader = javaClass.GetMethod<void(jni::jint, jni::jint, jni::String)>(
         *_env, "onPostCompileShader");
     cachedJavaPeer.Call(*_env,
-                       onPostCompileShader,
-                       static_cast<jni::jint>(id),
-                       static_cast<jni::jint>(type),
-                       jni::Make<jni::String>(*_env, additionalDefines));
+                        onPostCompileShader,
+                        static_cast<jni::jint>(id),
+                        static_cast<jni::jint>(type),
+                        jni::Make<jni::String>(*_env, additionalDefines));
 }
 
 void NativeMapView::onShaderCompileFailed(shaders::BuiltIn id,
@@ -2026,10 +2025,10 @@ void NativeMapView::onShaderCompileFailed(shaders::BuiltIn id,
     static auto onShaderCompileFailed = javaClass.GetMethod<void(jni::jint, jni::jint, jni::String)>(
         *_env, "onShaderCompileFailed");
     cachedJavaPeer.Call(*_env,
-                       onShaderCompileFailed,
-                       static_cast<jni::jint>(id),
-                       static_cast<jni::jint>(type),
-                       jni::Make<jni::String>(*_env, additionalDefines));
+                        onShaderCompileFailed,
+                        static_cast<jni::jint>(id),
+                        static_cast<jni::jint>(type),
+                        jni::Make<jni::String>(*_env, additionalDefines));
 }
 
 // Glyph requests
@@ -2107,14 +2106,14 @@ void NativeMapView::onTileAction(mbgl::TileOperation op, const OverscaledTileID&
         jni::Object<mbgl::android::TileOperation>, jni::jint, jni::jint, jni::jint, jni::jint, jni::jint, jni::String)>(
         *_env, "onTileAction");
     cachedJavaPeer.Call(*_env,
-                       onTileAction,
-                       mbgl::android::TileOperation::Create(*_env, op),
-                       static_cast<jni::jint>(id.canonical.x),
-                       static_cast<jni::jint>(id.canonical.y),
-                       static_cast<jni::jint>(id.canonical.z),
-                       static_cast<jni::jint>(id.wrap),
-                       static_cast<jni::jint>(id.overscaledZ),
-                       jni::Make<jni::String>(*_env, sourceID));
+                        onTileAction,
+                        mbgl::android::TileOperation::Create(*_env, op),
+                        static_cast<jni::jint>(id.canonical.x),
+                        static_cast<jni::jint>(id.canonical.y),
+                        static_cast<jni::jint>(id.canonical.z),
+                        static_cast<jni::jint>(id.wrap),
+                        static_cast<jni::jint>(id.overscaledZ),
+                        jni::Make<jni::String>(*_env, sourceID));
 }
 
 // Sprite requests
@@ -2130,11 +2129,12 @@ void NativeMapView::onSpriteLoaded(const std::optional<style::Sprite>& sprite) {
     static auto onSpriteLoaded = javaClass.GetMethod<void(jni::String, jni::String)>(*_env, "onSpriteLoaded");
     if (sprite) {
         cachedJavaPeer.Call(*_env,
-                           onSpriteLoaded,
-                           jni::Make<jni::String>(*_env, sprite->id),
-                           jni::Make<jni::String>(*_env, sprite->spriteURL));
+                            onSpriteLoaded,
+                            jni::Make<jni::String>(*_env, sprite->id),
+                            jni::Make<jni::String>(*_env, sprite->spriteURL));
     } else {
-        cachedJavaPeer.Call(*_env, onSpriteLoaded, jni::Make<jni::String>(*_env, ""), jni::Make<jni::String>(*_env, ""));
+        cachedJavaPeer.Call(
+            *_env, onSpriteLoaded, jni::Make<jni::String>(*_env, ""), jni::Make<jni::String>(*_env, ""));
     }
 }
 
@@ -2150,9 +2150,9 @@ void NativeMapView::onSpriteError(const std::optional<style::Sprite>& sprite, st
     static auto onSpriteError = javaClass.GetMethod<void(jni::String, jni::String)>(*_env, "onSpriteError");
     if (sprite) {
         cachedJavaPeer.Call(*_env,
-                           onSpriteError,
-                           jni::Make<jni::String>(*_env, sprite->id),
-                           jni::Make<jni::String>(*_env, sprite->spriteURL));
+                            onSpriteError,
+                            jni::Make<jni::String>(*_env, sprite->id),
+                            jni::Make<jni::String>(*_env, sprite->spriteURL));
     } else {
         cachedJavaPeer.Call(*_env, onSpriteError, jni::Make<jni::String>(*_env, ""), jni::Make<jni::String>(*_env, ""));
     }
@@ -2170,9 +2170,9 @@ void NativeMapView::onSpriteRequested(const std::optional<style::Sprite>& sprite
     static auto onSpriteRequested = javaClass.GetMethod<void(jni::String, jni::String)>(*_env, "onSpriteRequested");
     if (sprite) {
         cachedJavaPeer.Call(*_env,
-                           onSpriteRequested,
-                           jni::Make<jni::String>(*_env, sprite->id),
-                           jni::Make<jni::String>(*_env, sprite->spriteURL));
+                            onSpriteRequested,
+                            jni::Make<jni::String>(*_env, sprite->id),
+                            jni::Make<jni::String>(*_env, sprite->spriteURL));
     } else {
         cachedJavaPeer.Call(
             *_env, onSpriteRequested, jni::Make<jni::String>(*_env, ""), jni::Make<jni::String>(*_env, ""));

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/utils/MapFragmentUtils.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/utils/MapFragmentUtils.java
@@ -40,13 +40,13 @@ public class MapFragmentUtils {
    * @param args    The fragment arguments
    * @return converted MapLibreMapOptions
    */
-  @Nullable
+  @NonNull
   public static MapLibreMapOptions resolveArgs(@NonNull Context context, @Nullable Bundle args) {
-    MapLibreMapOptions options;
+    MapLibreMapOptions options = null;
     if (args != null && args.containsKey(MapLibreConstants.FRAG_ARG_MAPLIBREMAPOPTIONS)) {
       options = args.getParcelable(MapLibreConstants.FRAG_ARG_MAPLIBREMAPOPTIONS);
-    } else {
-      // load default options
+    }
+    if (options == null) {
       options = MapLibreMapOptions.createFromAttributes(context);
     }
     return options;

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -238,6 +238,7 @@ GLFWView::GLFWView(bool fullscreen_,
 
     glfwSetErrorCallback(glfwError);
     rmptr_ = std::make_unique<mbgl::route::RouteManager>();
+    rmptr_->setUseHighPrecisionTraffic(true);
     std::srand(static_cast<unsigned int>(std::time(nullptr)));
 
     if (!glfwInit()) {
@@ -318,17 +319,17 @@ GLFWView::GLFWView(bool fullscreen_,
     backend = GLFWBackend::Create(window, capFrameRate);
     backend->assetPath = MLN_ASSETS_PATH;
     if (testRunnerData.testName == "route_add_test") {
-        autoTest_ = std::make_unique<RouteAddTest>(testRunnerData.testDir);
+        autoTest_ = std::make_unique<RouteAddTest>(testRunnerData.testDir, rmptr_.get());
     } else if (testRunnerData.testName == "route_add_traffic_test") {
-        autoTest_ = std::make_unique<RouteAddTrafficTest>(testRunnerData.testDir);
+        autoTest_ = std::make_unique<RouteAddTrafficTest>(testRunnerData.testDir, rmptr_.get());
     } else if (testRunnerData.testName == "route_traffic_priority_test") {
-        autoTest_ = std::make_unique<RouteTrafficPriorityTest>(testRunnerData.testDir);
+        autoTest_ = std::make_unique<RouteTrafficPriorityTest>(testRunnerData.testDir, rmptr_.get());
     } else if (testRunnerData.testName == "route_pick_test") {
-        autoTest_ = std::make_unique<RoutePickTest>(testRunnerData.testDir);
+        autoTest_ = std::make_unique<RoutePickTest>(testRunnerData.testDir, rmptr_.get());
     } else if (testRunnerData.testName == "route_capture_test") {
-        autoTest_ = std::make_unique<RouteCaptureTest>(testRunnerData.testDir);
+        autoTest_ = std::make_unique<RouteCaptureTest>(testRunnerData.testDir, rmptr_.get());
     } else if (testRunnerData.testName == "route_nav_circle_test") {
-        autoTest_ = std::make_unique<RouteNavCircleTest>(testRunnerData.testDir);
+        autoTest_ = std::make_unique<RouteNavCircleTest>(testRunnerData.testDir, rmptr_.get());
     }
 
 #if defined(__APPLE__) && !defined(MLN_RENDER_BACKEND_VULKAN)
@@ -1018,7 +1019,7 @@ int GLFWView::getTopMost(const std::vector<RouteID> &routeList) const {
 }
 
 void GLFWView::addRoute() {
-    std::unique_ptr<RouteAddTest> addRoute = std::make_unique<RouteAddTest>("");
+    std::unique_ptr<RouteAddTest> addRoute = std::make_unique<RouteAddTest>("", rmptr_.get());
     addRoute->initTestFixtures(map);
     addRoute->produceTestCommands(map, this);
     addRoute->consumeTestCommand(map, this);
@@ -1047,7 +1048,7 @@ void GLFWView::setPuckLocation(double lat, double lon, double bearing) {
 }
 
 void GLFWView::addTrafficSegments() {
-    std::unique_ptr<RouteAddTrafficTest> addTraffic = std::make_unique<RouteAddTrafficTest>("");
+    std::unique_ptr<RouteAddTrafficTest> addTraffic = std::make_unique<RouteAddTrafficTest>("", rmptr_.get());
     addTraffic->initTestFixtures(map);
     addTraffic->produceTestCommands(map, this);
     addTraffic->consumeTestCommand(map, this);

--- a/platform/glfw/tests/route_add_test.cpp
+++ b/platform/glfw/tests/route_add_test.cpp
@@ -4,8 +4,8 @@
 #include "route_fixtures.hpp"
 #include "../glfw_view.hpp"
 
-RouteAddTest::RouteAddTest(const std::string& testDir)
-    : RouteTest("route_add_test", testDir) {}
+RouteAddTest::RouteAddTest(const std::string& testDir, mbgl::route::RouteManager* rm)
+    : RouteTest("route_add_test", testDir, rm) {}
 
 bool RouteAddTest::produceTestCommands(mbgl::Map* map, [[maybe_unused]] GLFWView* view) {
     assert(map != nullptr && "invalid map!");

--- a/platform/glfw/tests/route_add_test.hpp
+++ b/platform/glfw/tests/route_add_test.hpp
@@ -5,7 +5,7 @@
 class RouteAddTest : public RouteTest {
 public:
     RouteAddTest() = delete;
-    RouteAddTest(const std::string& testDir);
+    RouteAddTest(const std::string& testDir, mbgl::route::RouteManager* rm);
     bool produceTestCommands(mbgl::Map* map, GLFWView* view) override;
     ~RouteAddTest() override;
 };

--- a/platform/glfw/tests/route_add_traffic_test.cpp
+++ b/platform/glfw/tests/route_add_traffic_test.cpp
@@ -3,8 +3,8 @@
 #include "route_fixtures.hpp"
 #include "../glfw_view.hpp"
 
-RouteAddTrafficTest::RouteAddTrafficTest(const std::string &testDir)
-    : RouteTest("route_add_traffic_test", testDir) {}
+RouteAddTrafficTest::RouteAddTrafficTest(const std::string &testDir, mbgl::route::RouteManager *rm)
+    : RouteTest("route_add_traffic_test", testDir, rm) {}
 
 bool RouteAddTrafficTest::produceTestCommands([[maybe_unused]] mbgl::Map *map, [[maybe_unused]] GLFWView *view) {
     assert(map != nullptr && "invalid map!");

--- a/platform/glfw/tests/route_add_traffic_test.hpp
+++ b/platform/glfw/tests/route_add_traffic_test.hpp
@@ -6,7 +6,7 @@
 class RouteAddTrafficTest : public RouteTest {
 public:
     RouteAddTrafficTest() = delete;
-    RouteAddTrafficTest(const std::string& testDir);
+    RouteAddTrafficTest(const std::string& testDir, mbgl::route::RouteManager* rm);
     bool produceTestCommands(mbgl::Map* map, GLFWView* view) override;
     ~RouteAddTrafficTest() override;
 };

--- a/platform/glfw/tests/route_capture_test.cpp
+++ b/platform/glfw/tests/route_capture_test.cpp
@@ -4,8 +4,8 @@
 #include "rapidjson/document.h"
 #include <fstream>
 
-RouteCaptureTest::RouteCaptureTest(const std::string& testDir)
-    : RouteTest(testDir, "route_capture_test") {}
+RouteCaptureTest::RouteCaptureTest(const std::string& testDir, mbgl::route::RouteManager* rm)
+    : RouteTest(testDir, "route_capture_test", rm) {}
 
 bool RouteCaptureTest::readAndLoadCapture(const std::string& capture_file_name, mbgl::Map* map) {
     using namespace route_fixtures;

--- a/platform/glfw/tests/route_capture_test.hpp
+++ b/platform/glfw/tests/route_capture_test.hpp
@@ -4,7 +4,7 @@
 class RouteCaptureTest : public RouteTest {
 public:
     RouteCaptureTest() = delete;
-    RouteCaptureTest(const std::string& testDir);
+    RouteCaptureTest(const std::string& testDir, mbgl::route::RouteManager* rm);
     bool produceTestCommands(mbgl::Map* map, GLFWView* view) override;
     ~RouteCaptureTest() override;
 

--- a/platform/glfw/tests/route_nav_circle_test.cpp
+++ b/platform/glfw/tests/route_nav_circle_test.cpp
@@ -5,8 +5,8 @@
 #include "route_fixtures.hpp"
 #include "../glfw_view.hpp"
 
-RouteNavCircleTest::RouteNavCircleTest(const std::string testDir)
-    : RouteTest(testDir, "route_nav_circle_test") {}
+RouteNavCircleTest::RouteNavCircleTest(const std::string testDir, mbgl::route::RouteManager* rm)
+    : RouteTest(testDir, "route_nav_circle_test", rm) {}
 
 bool RouteNavCircleTest::produceTestCommands(mbgl::Map* map, GLFWView* view) {
     assert(map != nullptr && "invalid map!");

--- a/platform/glfw/tests/route_nav_circle_test.hpp
+++ b/platform/glfw/tests/route_nav_circle_test.hpp
@@ -5,7 +5,7 @@
 class RouteNavCircleTest : public RouteTest {
 public:
     RouteNavCircleTest() = delete;
-    RouteNavCircleTest(const std::string testDir);
+    RouteNavCircleTest(const std::string testDir, mbgl::route::RouteManager* rm);
     bool produceTestCommands(mbgl::Map* map, GLFWView* view) override;
     ~RouteNavCircleTest() override;
 };

--- a/platform/glfw/tests/route_pick_test.cpp
+++ b/platform/glfw/tests/route_pick_test.cpp
@@ -2,8 +2,8 @@
 #include "../glfw_view.hpp"
 #include "../glfw_renderer_frontend.hpp"
 
-RoutePickTest::RoutePickTest(const std::string& testDir)
-    : RouteTest("route_pick_test", testDir) {}
+RoutePickTest::RoutePickTest(const std::string& testDir, mbgl::route::RouteManager* rm)
+    : RouteTest("route_pick_test", testDir, rm) {}
 
 bool RoutePickTest::pickRoute(GLFWView* view, double x, double y) {
     pickedRouteID = RouteID();

--- a/platform/glfw/tests/route_pick_test.hpp
+++ b/platform/glfw/tests/route_pick_test.hpp
@@ -4,7 +4,7 @@
 class RoutePickTest : public RouteTest {
 public:
     RoutePickTest() = delete;
-    RoutePickTest(const std::string& testDir);
+    RoutePickTest(const std::string& testDir, mbgl::route::RouteManager* rm);
     bool produceTestCommands(mbgl::Map* map, GLFWView* view) override;
     ~RoutePickTest() override;
 

--- a/platform/glfw/tests/route_test.cpp
+++ b/platform/glfw/tests/route_test.cpp
@@ -1,16 +1,20 @@
 
 #include "route_test.hpp"
 
-RouteTest::RouteTest(const std::string& testDir, const std::string& testName)
-    : GLFWGraphicsTest(testName, testDir) {}
+RouteTest::RouteTest(const std::string& testDir, const std::string& testName, mbgl::route::RouteManager* routeManager)
+    : GLFWGraphicsTest(testName, testDir),
+      rmptr_(routeManager) {
+    assert(rmptr_ != nullptr && "RouteManager must not be null");
+    if (!rmptr_) {
+        throw std::invalid_argument("RouteManager pointer must not be null");
+    }
+}
 
 bool RouteTest::initTestFixtures([[maybe_unused]] mbgl::Map* map) {
     assert(map != nullptr && "invalid map!");
     bool status = false;
     if (map != nullptr) {
-        rmptr_ = std::make_unique<mbgl::route::RouteManager>();
         rmptr_->setStyle(map->getStyle());
-
         status = true;
     }
 

--- a/platform/glfw/tests/route_test.hpp
+++ b/platform/glfw/tests/route_test.hpp
@@ -9,7 +9,7 @@
 class RouteTest : public GLFWGraphicsTest {
 public:
     RouteTest() = delete;
-    RouteTest(const std::string& testDir, const std::string& testName);
+    RouteTest(const std::string& testDir, const std::string& testName, mbgl::route::RouteManager* routeManager);
     bool initTestFixtures(mbgl::Map* map) override;
     bool teardownTestFixtures(mbgl::Map* map) override;
     int consumeTestCommand(mbgl::Map* map, GLFWView* view) override;
@@ -19,7 +19,7 @@ public:
     ~RouteTest() override;
 
 protected:
-    std::unique_ptr<mbgl::route::RouteManager> rmptr_;
+    mbgl::route::RouteManager* rmptr_ = nullptr;
     std::unordered_map<RouteID, route_fixtures::RouteData, IDHasher<RouteID>> routeMap_;
     RouteID vanishingRouteID_;
 };

--- a/platform/glfw/tests/route_traffic_priority_test.cpp
+++ b/platform/glfw/tests/route_traffic_priority_test.cpp
@@ -1,8 +1,8 @@
 #include "route_traffic_priority_test.hpp"
 #include "../glfw_view.hpp"
 
-RouteTrafficPriorityTest::RouteTrafficPriorityTest(const std::string& testDir)
-    : RouteTest("route_traffic_priority_test", testDir) {}
+RouteTrafficPriorityTest::RouteTrafficPriorityTest(const std::string& testDir, mbgl::route::RouteManager* rm)
+    : RouteTest("route_traffic_priority_test", testDir, rm) {}
 
 bool RouteTrafficPriorityTest::produceTestCommands([[maybe_unused]] mbgl::Map* map, [[maybe_unused]] GLFWView* view) {
     assert(map != nullptr && "invalid map!");

--- a/platform/glfw/tests/route_traffic_priority_test.hpp
+++ b/platform/glfw/tests/route_traffic_priority_test.hpp
@@ -5,7 +5,7 @@
 class RouteTrafficPriorityTest : public RouteTest {
 public:
     RouteTrafficPriorityTest() = delete;
-    RouteTrafficPriorityTest(const std::string& testDir);
+    RouteTrafficPriorityTest(const std::string& testDir, mbgl::route::RouteManager* rm);
     bool produceTestCommands(mbgl::Map* map, GLFWView* view) override;
     ~RouteTrafficPriorityTest() override;
 

--- a/src/mbgl/renderer/layers/line_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/line_layer_tweaker.cpp
@@ -13,6 +13,7 @@
 #include <mbgl/shaders/line_layer_ubo.hpp>
 #include <mbgl/shaders/shader_program_base.hpp>
 #include <mbgl/style/layers/line_layer_properties.hpp>
+#include <mbgl/style/layers/line_layer_impl.hpp>
 #include <mbgl/util/logging.hpp>
 #include <mbgl/util/math.hpp>
 
@@ -72,6 +73,15 @@ void LineLayerTweaker::setGradientLineClip(double clip) {
 
 void LineLayerTweaker::setGradientLineClipColor(const mbgl::Color& color) {
     line_clip_color = color;
+}
+
+void LineLayerTweaker::setTrafficSegments(const std::vector<style::TrafficSegmentData>& segments,
+                                          bool useHighPrecision) {
+    trafficSegments_ = segments;
+    useHighPrecisionTraffic_ = useHighPrecision;
+    if (useHighPrecision) {
+        Log::Error(Event::Route, "LineLayerTweaker: using high precision traffic segment data");
+    }
 }
 
 void LineLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters& parameters) {
@@ -165,6 +175,24 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
     }
     auto& layerUniforms = layerGroup.mutableUniformBuffers();
     layerUniforms.set(idLineEvaluatedPropsUBO, evaluatedPropsUniformBuffer);
+
+    {
+        LineTrafficSegmentsUBO trafficUBO{};
+        trafficUBO.useHighPrecision = useHighPrecisionTraffic_ ? 1 : 0;
+        if (!trafficSegments_.empty()) {
+            trafficUBO.segmentCount = std::min(static_cast<int>(trafficSegments_.size()), MAX_ROUTE_TRAFFIC_SEGMENTS);
+            for (int s = 0; s < trafficUBO.segmentCount; s++) {
+                trafficUBO.segments[s].start = static_cast<float>(trafficSegments_[s].start);
+                trafficUBO.segments[s].end = static_cast<float>(trafficSegments_[s].end);
+                trafficUBO.segments[s].color = {trafficSegments_[s].color.r,
+                                                trafficSegments_[s].color.g,
+                                                trafficSegments_[s].color.b,
+                                                trafficSegments_[s].color.a};
+            }
+        }
+        context.emplaceOrUpdateUniformBuffer(trafficSegmentsUniformBuffer, &trafficUBO);
+        layerUniforms.set(idLineTrafficSegmentsUBO, trafficSegmentsUniformBuffer);
+    }
 
 #if MLN_RENDER_BACKEND_METAL
     // GPU Expressions

--- a/src/mbgl/renderer/layers/line_layer_tweaker.hpp
+++ b/src/mbgl/renderer/layers/line_layer_tweaker.hpp
@@ -2,12 +2,14 @@
 
 #include <mbgl/renderer/layer_tweaker.hpp>
 #include <mbgl/style/layers/line_layer_properties.hpp>
+#include <mbgl/style/layers/line_layer_impl.hpp>
 
 #if MLN_RENDER_BACKEND_METAL
 #include <mbgl/shaders/line_layer_ubo.hpp>
 #endif // MLN_RENDER_BACKEND_METAL
 
 #include <string>
+#include <vector>
 
 namespace mbgl {
 
@@ -35,6 +37,7 @@ public:
 
     void setGradientLineClip(double clip);
     void setGradientLineClipColor(const mbgl::Color& color);
+    void setTrafficSegments(const std::vector<style::TrafficSegmentData>& segments, bool useHighPrecision);
 
     void execute(LayerGroupBase&, const PaintParameters&) override;
 
@@ -54,6 +57,9 @@ private:
     auto evaluate(const PaintParameters& parameters) const;
     double line_clip_ = 0.0;
     mbgl::Color line_clip_color = mbgl::Color(0.0, 0.0, 0.0, 0.0);
+    std::vector<style::TrafficSegmentData> trafficSegments_;
+    bool useHighPrecisionTraffic_ = false;
+    gfx::UniformBufferPtr trafficSegmentsUniformBuffer;
 
 #if MLN_RENDER_BACKEND_METAL
     template <typename Result>

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -591,8 +591,9 @@ void RenderLineLayer::update(gfx::ShaderRegistry& shaders,
                     addDrawable(std::move(drawable), LineLayerTweaker::LineType::Pattern);
                 }
             }
-        } else if (!unevaluated.get<LineGradient>().getValue().isUndefined()) {
-            // gradient line
+        } else if (!unevaluated.get<LineGradient>().getValue().isUndefined() ||
+                   impl_cast(baseImpl).useHighPrecisionTraffic) {
+            // gradient line or high-precision traffic segments
             if (!lineGradientShaderGroup) {
                 lineGradientShaderGroup = shaders.getShaderGroup("LineGradientShader");
                 if (!lineGradientShaderGroup) {
@@ -615,6 +616,11 @@ void RenderLineLayer::update(gfx::ShaderRegistry& shaders,
                     LineLayerTweakerPtr lineLayerTweaker = std::static_pointer_cast<LineLayerTweaker>(layerTweaker);
                     lineLayerTweaker->setGradientLineClipColor(currLineClipColorValue);
                 }
+            }
+            if (layerTweaker) {
+                auto lineLayerTweaker = std::static_pointer_cast<LineLayerTweaker>(layerTweaker);
+                lineLayerTweaker->setTrafficSegments(impl_cast(baseImpl).trafficSegments,
+                                                     impl_cast(baseImpl).useHighPrecisionTraffic);
             }
             auto shader = lineGradientShaderGroup->getOrCreateShader(
                 context, propertiesAsUniforms, posNormalAttribName);
@@ -642,7 +648,9 @@ void RenderLineLayer::update(gfx::ShaderRegistry& shaders,
 
             if (colorRampTexture2D) {
                 builder->setTexture(colorRampTexture2D, idLineImageTexture);
+            }
 
+            if (colorRampTexture2D || impl_cast(baseImpl).useHighPrecisionTraffic) {
                 setSegments(builder, bucket);
 
                 builder->flush(context);

--- a/src/mbgl/route/route.cpp
+++ b/src/mbgl/route/route.cpp
@@ -169,7 +169,7 @@ Route::Route(const LineString<double>& geometry, const RouteOptions& ropts)
 
     if (geometry_.size() < 2) {
         throw std::invalid_argument("Route geometry must contain at least 2 points, got: " +
-                                   std::to_string(geometry_.size()));
+                                    std::to_string(geometry_.size()));
     }
 
     if (std::isnan(geometry_[0].x) || std::isnan(geometry_[0].y)) {
@@ -188,8 +188,8 @@ Route::Route(const LineString<double>& geometry, const RouteOptions& ropts)
 
         // Validate each point
         if (std::isnan(p1.x) || std::isnan(p1.y) || std::isnan(p2.x) || std::isnan(p2.y)) {
-            throw std::invalid_argument("Invalid geometry point at index " + std::to_string(i) +
-                                       " or " + std::to_string(i + 1) + ": coordinates cannot be NaN");
+            throw std::invalid_argument("Invalid geometry point at index " + std::to_string(i) + " or " +
+                                        std::to_string(i + 1) + ": coordinates cannot be NaN");
         }
 
         double segLen;
@@ -500,6 +500,10 @@ std::map<double, mbgl::Color> Route::getRouteColorStops(const mbgl::Color& route
 }
 
 std::vector<Route::SegmentRange> Route::compactSegments(const RouteType& routeType) const {
+    if (segments_.empty()) {
+        return {};
+    }
+
     std::vector<RouteSegment> segments = segments_;
 
     std::sort(segments.begin(), segments.end(), [](const RouteSegment& a, const RouteSegment& b) {
@@ -617,10 +621,10 @@ std::map<double, mbgl::Color> Route::getRouteSegmentColorStops(const RouteType& 
             double pre_pos = firstPos - HALF_EPSILON < 0.0 ? 0.0 : firstPos - HALF_EPSILON;
             colorStops[pre_pos] = routeColor;
         }
-        
+
         colorStops[firstPos] = sr.color;
         colorStops[lastPos] = sr.color;
-        
+
         if (needPostTransition) {
             double post_pos = lastPos + HALF_EPSILON > 1.0 ? 1.0 : lastPos + HALF_EPSILON;
             colorStops[post_pos] = routeColor;

--- a/src/mbgl/route/route_manager.cpp
+++ b/src/mbgl/route/route_manager.cpp
@@ -335,7 +335,7 @@ int RouteManager::getTopMost(const std::vector<RouteID>& routeList) const {
 
         if (!layers.empty()) {
             int layercount = static_cast<int>(layers.size());
-            for (int i = layercount-1; i >= 0; i--) {
+            for (int i = layercount - 1; i >= 0; i--) {
                 const std::string currLayerName = layers[i]->getID();
 
                 for (size_t j = 0; j < routeList.size(); j++) {
@@ -1143,6 +1143,7 @@ void RouteManager::finalizeRoute(const RouteID& routeID, const DirtyType& dt) {
         layer->setGradientLineFilter(LineGradientFilterType::Nearest);
         layer->setGradientLineClipColor(clipColor);
         layer->setIsLayerUsingRoute(true);
+        layer->setUseHighPrecisionTraffic(useHighPrecisionTraffic_);
 
         if (zoomstops.empty()) {
             layer->setLineWidth(width);
@@ -1189,11 +1190,13 @@ void RouteManager::finalizeRoute(const RouteID& routeID, const DirtyType& dt) {
     if (routeID.isValid() && routeMap_.find(routeID) != routeMap_.end()) {
         bool updateRouteLayers = false;
         bool updateGradients = false;
+        bool updateTrafficSegments = false;
         bool updateProgress = false;
         switch (dt) {
             case DirtyType::dtRouteGeometry: {
                 updateRouteLayers = true;
-                updateGradients = true;
+                updateGradients = !useHighPrecisionTraffic_;
+                updateTrafficSegments = useHighPrecisionTraffic_;
                 updateProgress = true;
             } break;
 
@@ -1202,7 +1205,8 @@ void RouteManager::finalizeRoute(const RouteID& routeID, const DirtyType& dt) {
             } break;
 
             case DirtyType::dtRouteSegments: {
-                updateGradients = true;
+                updateGradients = !useHighPrecisionTraffic_;
+                updateTrafficSegments = useHighPrecisionTraffic_;
             } break;
         }
 
@@ -1262,28 +1266,39 @@ void RouteManager::finalizeRoute(const RouteID& routeID, const DirtyType& dt) {
             mbgl::Log::Info(mbgl::Event::Style, "Trying to update a layer that is not created");
         }
 
-        // Create the gradient colors expressions and set on the active layer
         std::unordered_map<std::string, std::string> gradientDebugMap;
         if (updateGradients) {
-            // create the gradient expression for active route.
             std::map<double, mbgl::Color> innerGradientMap = route.getRouteSegmentColorStops(RouteType::Inner,
                                                                                              routeOptions.innerColor);
-
             std::unique_ptr<expression::Expression> innerGradientExpression = createGradientExpression(
                 innerGradientMap);
-
             ColorRampPropertyValue activeColorRampProp(std::move(innerGradientExpression));
             activeRouteLineLayer->setLineGradient(activeColorRampProp);
 
-            // create the gradient expression for the base route
             std::map<double, mbgl::Color> casingLayerGradient = route.getRouteSegmentColorStops(
                 RouteType::Casing, routeOptions.outerColor);
-            // std::map<double, mbgl::Color> casingLayerGradient = route.getRouteColorStops(routeOptions.outerColor);
             std::unique_ptr<expression::Expression> casingLayerExpression = createGradientExpression(
                 casingLayerGradient);
-
             ColorRampPropertyValue casingColorRampProp(std::move(casingLayerExpression));
             casingRouteLineLayer->setLineGradient(casingColorRampProp);
+        }
+
+        if (updateTrafficSegments) {
+            auto toTrafficSegments =
+                [](const std::vector<Route::SegmentRange>& ranges) -> std::vector<style::LineLayer::TrafficSegment> {
+                std::vector<style::LineLayer::TrafficSegment> result;
+                result.reserve(ranges.size());
+                for (const auto& sr : ranges) {
+                    result.push_back({sr.range.first, sr.range.second, sr.color});
+                }
+                return result;
+            };
+
+            auto innerSegments = route.compactSegments(RouteType::Inner);
+            activeRouteLineLayer->setTrafficSegments(toTrafficSegments(innerSegments));
+
+            auto casingSegments = route.compactSegments(RouteType::Casing);
+            casingRouteLineLayer->setTrafficSegments(toTrafficSegments(casingSegments));
         }
 
         if (updateProgress) {
@@ -1413,7 +1428,7 @@ void RouteManager::applyEmergencyDiagnostics() {
         }
         layerInfo << "]";
         Log::Warning(Event::Route, "Layers in route proximity: " + layerInfo.str());
-        Log::Warning(Event::Route, "Route stats: "+getStats());
+        Log::Warning(Event::Route, "Route stats: " + getStats());
 
     } else {
         Log::Info(Event::Route, "Route diagnostics applied and found no issues ");
@@ -1444,6 +1459,14 @@ void RouteManager::finalize() {
     stats_.finalizeMillis = duration_cast<milliseconds>(stopclock - startclock).count();
 
     TRACE_ROUTE_CALL(stats_.recentApiCalls, {}, "void", "", {}, "");
+}
+
+void RouteManager::setUseHighPrecisionTraffic(bool useHighPrecision) {
+    useHighPrecisionTraffic_ = useHighPrecision;
+}
+
+bool RouteManager::getUseHighPrecisionTraffic() const {
+    return useHighPrecisionTraffic_;
 }
 
 RouteManager::~RouteManager() {}

--- a/src/mbgl/shaders/gl/shader_info.cpp
+++ b/src/mbgl/shaders/gl/shader_info.cpp
@@ -367,6 +367,7 @@ const std::vector<UniformBlockInfo> LineGradientShaderInfo::uniformBlocks = {
     UniformBlockInfo{"GlobalPaintParamsUBO", idGlobalPaintParamsUBO},
     UniformBlockInfo{"LineGradientDrawableUBO", idLineDrawableUBO},
     UniformBlockInfo{"LineEvaluatedPropsUBO", idLineEvaluatedPropsUBO},
+    UniformBlockInfo{"LineTrafficSegmentsUBO", idLineTrafficSegmentsUBO},
 };
 const std::vector<AttributeInfo> LineGradientShaderInfo::attributes = {
     AttributeInfo{"a_pos_normal", idLinePosNormalVertexAttribute},

--- a/src/mbgl/shaders/gl/shader_program_gl.cpp
+++ b/src/mbgl/shaders/gl/shader_program_gl.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/shaders/gl/shader_program_gl.hpp>
 
 #include <mbgl/gl/defines.hpp>
+#include <mbgl/util/logging.hpp>
 #include <mbgl/gl/types.hpp>
 #include <mbgl/gl/vertex_attribute_gl.hpp>
 #include <mbgl/platform/gl_functions.hpp>
@@ -142,9 +143,17 @@ std::shared_ptr<ShaderProgramGL> ShaderProgramGL::create(
 
         for (const auto& blockInfo : uniformBlocksInfo) {
             GLint index = MBGL_CHECK_ERROR(glGetUniformBlockIndex(program, blockInfo.name.data()));
+            if (index == static_cast<GLint>(GL_INVALID_INDEX)) {
+                continue;
+            }
             GLint size = 0;
             MBGL_CHECK_ERROR(glGetActiveUniformBlockiv(program, index, GL_UNIFORM_BLOCK_DATA_SIZE, &size));
-            assert(size > 0);
+            if (size <= 0) {
+                Log::Error(
+                    Event::Shader,
+                    "Uniform block '" + std::string(blockInfo.name) + "' has invalid size " + std::to_string(size));
+                continue;
+            }
             GLint binding = static_cast<GLint>(blockInfo.binding);
             MBGL_CHECK_ERROR(glUniformBlockBinding(program, index, binding));
         }
@@ -152,7 +161,6 @@ std::shared_ptr<ShaderProgramGL> ShaderProgramGL::create(
         SamplerLocationArray samplerLocations;
         for (const auto& textureInfo : texturesInfo) {
             GLint location = MBGL_CHECK_ERROR(glGetUniformLocation(program, textureInfo.name.data()));
-            assert(location != -1);
             if (location != -1) {
                 samplerLocations[textureInfo.id] = location;
             }

--- a/src/mbgl/style/layers/line_layer.cpp
+++ b/src/mbgl/style/layers/line_layer.cpp
@@ -496,6 +496,31 @@ const PropertyValue<Color>& LineLayer::getGradientLineClipColor() const {
     return impl().paint.template get<LineClipColor>().value;
 }
 
+void LineLayer::setUseHighPrecisionTraffic(bool useHighPrecision) {
+    if (useHighPrecision == getUseHighPrecisionTraffic()) {
+        return;
+    }
+    auto impl_ = mutableImpl();
+    impl_->useHighPrecisionTraffic = useHighPrecision;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+bool LineLayer::getUseHighPrecisionTraffic() const {
+    return impl().useHighPrecisionTraffic;
+}
+
+void LineLayer::setTrafficSegments(std::vector<TrafficSegment> segments) {
+    auto impl_ = mutableImpl();
+    impl_->trafficSegments.clear();
+    impl_->trafficSegments.reserve(segments.size());
+    for (const auto& seg : segments) {
+        impl_->trafficSegments.push_back({seg.start, seg.end, seg.color});
+    }
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
 using namespace conversion;
 
 namespace {

--- a/src/mbgl/style/layers/line_layer_impl.hpp
+++ b/src/mbgl/style/layers/line_layer_impl.hpp
@@ -3,9 +3,17 @@
 #include <mbgl/style/layer_impl.hpp>
 #include <mbgl/style/layers/line_layer.hpp>
 #include <mbgl/style/layers/line_layer_properties.hpp>
+#include <mbgl/util/color.hpp>
+#include <vector>
 
 namespace mbgl {
 namespace style {
+
+struct TrafficSegmentData {
+    double start;
+    double end;
+    Color color;
+};
 
 class LineLayer::Impl : public Layer::Impl {
 public:
@@ -22,6 +30,8 @@ public:
     LinePaintProperties::Transitionable paint;
     LineGradientFilterType gradientFilterType = LineGradientFilterType::Linear;
     bool isRouteLayer = false;
+    std::vector<TrafficSegmentData> trafficSegments;
+    bool useHighPrecisionTraffic = false;
 
     DECLARE_LAYER_TYPE_INFO;
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(
     ${PROJECT_SOURCE_DIR}/test/math/wrap.test.cpp
     ${PROJECT_SOURCE_DIR}/test/platform/settings.test.cpp
     ${PROJECT_SOURCE_DIR}/test/programs/symbol_program.test.cpp
+    ${PROJECT_SOURCE_DIR}/test/route/route_traffic.test.cpp
     ${PROJECT_SOURCE_DIR}/test/renderer/image_manager.test.cpp
     ${PROJECT_SOURCE_DIR}/test/renderer/pattern_atlas.test.cpp
     ${PROJECT_SOURCE_DIR}/test/renderer/shader_registry.test.cpp

--- a/test/route/route_traffic.test.cpp
+++ b/test/route/route_traffic.test.cpp
@@ -1,0 +1,217 @@
+#include <mbgl/test/util.hpp>
+
+#include <mbgl/route/route.hpp>
+#include <mbgl/route/route_manager.hpp>
+#include <mbgl/route/route_segment.hpp>
+#include <mbgl/route/route_enums.hpp>
+#include <mbgl/shaders/line_layer_ubo.hpp>
+#include <mbgl/style/layers/line_layer_impl.hpp>
+#include <mbgl/util/color.hpp>
+
+#include <cstddef>
+#include <vector>
+
+using namespace mbgl;
+using namespace mbgl::route;
+using namespace mbgl::shaders;
+
+namespace {
+
+LineString<double> makeCircleGeometry(float radius, int resolution) {
+    LineString<double> line;
+    for (int i = 0; i < resolution; i++) {
+        float angle = (static_cast<float>(i) / static_cast<float>(resolution - 1)) * 2.0f * 3.14159f;
+        line.push_back({radius * std::sin(angle), radius * std::cos(angle)});
+    }
+    return line;
+}
+
+Route makeTestRoute(int numPoints = 10, float radius = 50.0f) {
+    RouteOptions opts;
+    opts.useMercatorProjection = false;
+    return Route(makeCircleGeometry(radius, numPoints), opts);
+}
+
+} // namespace
+
+// 1. compactSegments returns empty when no segments are added
+TEST(RouteTraffic, CompactSegmentsEmpty) {
+    Route route = makeTestRoute();
+    auto segments = route.compactSegments(RouteType::Inner);
+    EXPECT_TRUE(segments.empty());
+}
+
+// 2. compactSegments with a single segment
+TEST(RouteTraffic, CompactSegmentsSingle) {
+    Route route = makeTestRoute();
+
+    RouteSegmentOptions segOpts;
+    segOpts.firstIndex = 0;
+    segOpts.firstIndexFraction = 0.0f;
+    segOpts.lastIndex = 0;
+    segOpts.lastIndexFraction = 1.0f;
+    segOpts.color = Color(1.0f, 0.0f, 0.0f, 1.0f);
+    segOpts.priority = 0;
+
+    EXPECT_TRUE(route.routeSegmentCreate(segOpts));
+
+    auto segments = route.compactSegments(RouteType::Inner);
+    ASSERT_EQ(segments.size(), 1u);
+    EXPECT_GT(segments[0].range.second, segments[0].range.first);
+    EXPECT_GE(segments[0].range.first, 0.0);
+    EXPECT_LE(segments[0].range.second, 1.0);
+}
+
+// 3. compactSegments with multiple non-overlapping segments
+TEST(RouteTraffic, CompactSegmentsMultipleNonOverlapping) {
+    Route route = makeTestRoute();
+
+    RouteSegmentOptions seg0;
+    seg0.firstIndex = 0;
+    seg0.firstIndexFraction = 0.0f;
+    seg0.lastIndex = 0;
+    seg0.lastIndexFraction = 1.0f;
+    seg0.color = Color(1.0f, 0.0f, 0.0f, 1.0f);
+    seg0.priority = 0;
+
+    RouteSegmentOptions seg1;
+    seg1.firstIndex = 3;
+    seg1.firstIndexFraction = 0.0f;
+    seg1.lastIndex = 3;
+    seg1.lastIndexFraction = 1.0f;
+    seg1.color = Color(0.0f, 1.0f, 0.0f, 1.0f);
+    seg1.priority = 0;
+
+    RouteSegmentOptions seg2;
+    seg2.firstIndex = 6;
+    seg2.firstIndexFraction = 0.0f;
+    seg2.lastIndex = 6;
+    seg2.lastIndexFraction = 1.0f;
+    seg2.color = Color(0.0f, 0.0f, 1.0f, 1.0f);
+    seg2.priority = 0;
+
+    EXPECT_TRUE(route.routeSegmentCreate(seg0));
+    EXPECT_TRUE(route.routeSegmentCreate(seg1));
+    EXPECT_TRUE(route.routeSegmentCreate(seg2));
+
+    auto segments = route.compactSegments(RouteType::Inner);
+    ASSERT_EQ(segments.size(), 3u);
+
+    for (size_t i = 0; i < segments.size(); i++) {
+        EXPECT_GT(segments[i].range.second, segments[i].range.first);
+        EXPECT_GE(segments[i].range.first, 0.0);
+        EXPECT_LE(segments[i].range.second, 1.0);
+    }
+    EXPECT_LT(segments[0].range.second, segments[1].range.first);
+    EXPECT_LT(segments[1].range.second, segments[2].range.first);
+}
+
+// 4. compactSegments with overlapping segments and priority
+TEST(RouteTraffic, CompactSegmentsOverlappingPriority) {
+    Route route = makeTestRoute();
+
+    RouteSegmentOptions segLow;
+    segLow.firstIndex = 1;
+    segLow.firstIndexFraction = 0.0f;
+    segLow.lastIndex = 3;
+    segLow.lastIndexFraction = 1.0f;
+    segLow.color = Color(1.0f, 0.0f, 0.0f, 1.0f);
+    segLow.priority = 0;
+
+    RouteSegmentOptions segHigh;
+    segHigh.firstIndex = 2;
+    segHigh.firstIndexFraction = 0.0f;
+    segHigh.lastIndex = 4;
+    segHigh.lastIndexFraction = 1.0f;
+    segHigh.color = Color(0.0f, 1.0f, 0.0f, 1.0f);
+    segHigh.priority = 1;
+
+    EXPECT_TRUE(route.routeSegmentCreate(segLow));
+    EXPECT_TRUE(route.routeSegmentCreate(segHigh));
+
+    auto segments = route.compactSegments(RouteType::Inner);
+    ASSERT_GE(segments.size(), 2u);
+
+    for (const auto& seg : segments) {
+        EXPECT_GT(seg.range.second, seg.range.first);
+        EXPECT_GE(seg.range.first, 0.0);
+        EXPECT_LE(seg.range.second, 1.0);
+    }
+}
+
+// 5. RouteManager toggle API
+TEST(RouteTraffic, HighPrecisionToggle) {
+    RouteManager rm;
+    EXPECT_FALSE(rm.getUseHighPrecisionTraffic());
+
+    rm.setUseHighPrecisionTraffic(true);
+    EXPECT_TRUE(rm.getUseHighPrecisionTraffic());
+
+    rm.setUseHighPrecisionTraffic(false);
+    EXPECT_FALSE(rm.getUseHighPrecisionTraffic());
+}
+
+// 6. UBO struct layout matches expected sizes and offsets
+TEST(RouteTraffic, UBOStructLayout) {
+    EXPECT_EQ(sizeof(RouteTrafficSegmentData), 32u);
+    EXPECT_EQ(sizeof(LineTrafficSegmentsUBO), 65u * 16u);
+    EXPECT_EQ(offsetof(LineTrafficSegmentsUBO, useHighPrecision), 1024u);
+    EXPECT_EQ(offsetof(LineTrafficSegmentsUBO, segmentCount), 1028u);
+}
+
+// 7. UBO population logic
+TEST(RouteTraffic, UBOPopulation) {
+    std::vector<style::TrafficSegmentData> input = {
+        {0.1, 0.3, Color(1.0f, 0.0f, 0.0f, 1.0f)},
+        {0.5, 0.7, Color(0.0f, 1.0f, 0.0f, 1.0f)},
+        {0.8, 0.95, Color(0.0f, 0.0f, 1.0f, 1.0f)},
+    };
+
+    LineTrafficSegmentsUBO ubo{};
+    ubo.useHighPrecision = 1;
+    ubo.segmentCount = std::min(static_cast<int>(input.size()), MAX_ROUTE_TRAFFIC_SEGMENTS);
+
+    for (int i = 0; i < ubo.segmentCount; i++) {
+        ubo.segments[i].start = static_cast<float>(input[i].start);
+        ubo.segments[i].end = static_cast<float>(input[i].end);
+        ubo.segments[i].color = {input[i].color.r, input[i].color.g, input[i].color.b, input[i].color.a};
+    }
+
+    EXPECT_EQ(ubo.useHighPrecision, 1);
+    EXPECT_EQ(ubo.segmentCount, 3);
+
+    EXPECT_FLOAT_EQ(ubo.segments[0].start, 0.1f);
+    EXPECT_FLOAT_EQ(ubo.segments[0].end, 0.3f);
+    EXPECT_FLOAT_EQ(ubo.segments[0].color[0], 1.0f);
+    EXPECT_FLOAT_EQ(ubo.segments[0].color[1], 0.0f);
+
+    EXPECT_FLOAT_EQ(ubo.segments[1].start, 0.5f);
+    EXPECT_FLOAT_EQ(ubo.segments[1].end, 0.7f);
+    EXPECT_FLOAT_EQ(ubo.segments[1].color[1], 1.0f);
+
+    EXPECT_FLOAT_EQ(ubo.segments[2].start, 0.8f);
+    EXPECT_FLOAT_EQ(ubo.segments[2].end, 0.95f);
+    EXPECT_FLOAT_EQ(ubo.segments[2].color[2], 1.0f);
+}
+
+// 8. MAX_ROUTE_TRAFFIC_SEGMENTS clamping
+TEST(RouteTraffic, UBOSegmentClamping) {
+    std::vector<style::TrafficSegmentData> input;
+    for (int i = 0; i < MAX_ROUTE_TRAFFIC_SEGMENTS + 10; i++) {
+        double start = static_cast<double>(i) / (MAX_ROUTE_TRAFFIC_SEGMENTS + 10);
+        double end = start + 0.005;
+        input.push_back({start, end, Color(1.0f, 0.0f, 0.0f, 1.0f)});
+    }
+
+    LineTrafficSegmentsUBO ubo{};
+    ubo.segmentCount = std::min(static_cast<int>(input.size()), MAX_ROUTE_TRAFFIC_SEGMENTS);
+
+    for (int i = 0; i < ubo.segmentCount; i++) {
+        ubo.segments[i].start = static_cast<float>(input[i].start);
+        ubo.segments[i].end = static_cast<float>(input[i].end);
+        ubo.segments[i].color = {input[i].color.r, input[i].color.g, input[i].color.b, input[i].color.a};
+    }
+
+    EXPECT_EQ(ubo.segmentCount, MAX_ROUTE_TRAFFIC_SEGMENTS);
+    EXPECT_EQ(static_cast<int>(input.size()), MAX_ROUTE_TRAFFIC_SEGMENTS + 10);
+}


### PR DESCRIPTION
This MR adds support for high resolution traffic segments from using textures with traffic segment. We directly send a UBO with an array of traffic ranges and colors and color the fragment with that data. Tested in native GLFW test app and in RouteActivity android test app. 

I have flipped to use high precision traffic by default  in this branch.

The other change (which touched a lot of test code files is that previously the RouteManager was instantiated by the test. But now, the RouteManager is passed from externally. All of the RouteTests are based on GLFWview and the GLFWview already houses a RouteManager).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alproton/maplibre-native/106)
<!-- Reviewable:end -->
